### PR TITLE
use shaded egit-github artifact, allows GitHubApiTest to pass

### DIFF
--- a/github-android-integration-tests/src/main/java/com/github/mobile/android/GitHubApiTest.java
+++ b/github-android-integration-tests/src/main/java/com/github/mobile/android/GitHubApiTest.java
@@ -11,7 +11,7 @@ public class GitHubApiTest extends AndroidTestCase {
 
     public void testRepoApi() throws Exception {
         RepositoryService service = new RepositoryService();
-    	for (Repository repo : service.getRepositories("defunkt")) {
+    	for (Repository repo : service.getRepositories("git")) {
             Log.d(TAG, repo.getName() + " Watchers: " + repo.getWatchers());
         }
     }

--- a/github-android/pom.xml
+++ b/github-android/pom.xml
@@ -12,6 +12,12 @@
 
     <packaging>apk</packaging>
     <name>GitHub for Android</name>
+    <repositories>
+        <repository>
+            <id>github-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/comgithubgithub-313</url>
+        </repository>
+    </repositories>
     <dependencies>
 
         <dependency>
@@ -51,9 +57,9 @@
             <version>2.0</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.mylyn.github</groupId>
-            <artifactId>org.eclipse.egit.github.core</artifactId>
-            <version>1.1.1</version>
+            <groupId>com.github.github</groupId>
+            <artifactId>org.eclipse.egit.github.core.shaded</artifactId>
+            <version>1.1.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/github-android/src/main/java/com/github/mobile/android/LogFactory.java
+++ b/github-android/src/main/java/com/github/mobile/android/LogFactory.java
@@ -7,13 +7,13 @@ import static android.util.Log.isLoggable;
 import static android.util.Log.v;
 import static android.util.Log.w;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogConfigurationException;
+import shade.org.apache.commons.logging.Log;
+import shade.org.apache.commons.logging.LogConfigurationException;
 
 /**
  * Log
  */
-public class LogFactory extends org.apache.commons.logging.LogFactory {
+public class LogFactory extends shade.org.apache.commons.logging.LogFactory {
 
 	private final String TAG = "GHLog";
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
                             <lib>${rt.jar.path}</lib>
                             <lib>${jsse.jar.path}</lib>
                         </libs>
-                        <obfuscate>true</obfuscate>
+                        <obfuscate>false</obfuscate>
                         <addMavenDescriptor>false</addMavenDescriptor>
                         <proguardInclude>../proguard.cfg</proguardInclude>
                         <!-- sadly, relative to sub-modules -->

--- a/proguard.cfg
+++ b/proguard.cfg
@@ -1,7 +1,4 @@
 
--keeppackagenames !org.apache.**
--keepnames class !org.apache.** { *; }
--keepattributes Signature
 
 -keepclassmembers enum * { public static **[] values(); public static ** valueOf(java.lang.String); }
 


### PR DESCRIPTION
hey @kevinsawicki - can you see if 'mvn clean install' works for you on this branch? For me, using the shaded jar here works and unlike 12fe8c642d, the GitHubApiTest passes:

[INFO] Running instrumentation tests in com.github.mobile.android.tests on HT16NV802248 (avdName=null)
[INFO]   Run started: com.github.mobile.android.tests, 3 tests:
[INFO]     Start: com.github.mobile.android.DashboardActivityTest#testSomething
[INFO]     End: com.github.mobile.android.DashboardActivityTest#testSomething
[INFO]     Start: com.github.mobile.android.GitHubApiTest#testAndroidTestCaseSetupProperly
[INFO]     End: com.github.mobile.android.GitHubApiTest#testAndroidTestCaseSetupProperly
[INFO]     Start: com.github.mobile.android.GitHubApiTest#testRepoApi
[INFO]     End: com.github.mobile.android.GitHubApiTest#testRepoApi
[INFO]   Run ended: 1742 ms
[INFO]   Tests run: 3,  Failures: 0,  Errors: 0

If we want to use the shaded jar, better release the shaded jar into maven central from:

https://oss.sonatype.org/content/repositories/comgithubgithub-313/com/github/github/org.eclipse.egit.github.core.shaded/
