### PR TITLE
Fix initiation/ensuring of user-login

### DIFF
--- a/app/src/main/java/com/github/mobile/android/DashboardActivity.java
+++ b/app/src/main/java/com/github/mobile/android/DashboardActivity.java
@@ -37,9 +37,6 @@ public class DashboardActivity extends RoboSherlockFragmentActivity {
     private ViewPager viewPager;
     private TabsAdapter tabsAdapter;
 
-    @Inject
-    ContextScopedProvider<Account> currentAccountProvider;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -58,14 +55,6 @@ public class DashboardActivity extends RoboSherlockFragmentActivity {
 
         if (savedInstanceState != null) {
             tabHost.setCurrentTabByTag(savedInstanceState.getString(BUNDLE_KEY_TAB));
-        }
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        if (currentAccountProvider.get(this) == null) {
-            startActivityForResult(new Intent(this, WelcomeActivity.class), 0);
         }
     }
 

--- a/app/src/main/java/com/github/mobile/android/HomeActivity.java
+++ b/app/src/main/java/com/github/mobile/android/HomeActivity.java
@@ -30,9 +30,6 @@ public class HomeActivity extends RoboSherlockFragmentActivity {
     private static final String TAG = "HA";
     private static final int CODE_LOGIN = 1;
 
-    @Inject
-    private ContextScopedProvider<Account> accountProvider;
-
     @Override
     public boolean onCreateOptionsMenu(Menu optionMenu) {
         getSupportMenuInflater().inflate(menu.welcome, optionMenu);
@@ -85,10 +82,6 @@ public class HomeActivity extends RoboSherlockFragmentActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        if (accountProvider.get(this) == null) {
-            Log.d(TAG, "No account currently available, starting Welcome activity");
-            startActivityForResult(new Intent(this, WelcomeActivity.class), CODE_LOGIN);
-        } else
-            loadOrgs();
+        loadOrgs();
     }
 }

--- a/app/src/main/java/com/github/mobile/android/async/AuthenticatedUserTask.java
+++ b/app/src/main/java/com/github/mobile/android/async/AuthenticatedUserTask.java
@@ -1,0 +1,53 @@
+package com.github.mobile.android.async;
+
+
+import android.app.Activity;
+import android.content.Context;
+
+import com.github.mobile.android.guice.GitHubAccountScope;
+import com.google.inject.Inject;
+
+import java.util.concurrent.Executor;
+
+import roboguice.inject.ContextScope;
+import roboguice.util.RoboAsyncTask;
+
+/**
+ * Enforces that user is logged in before work on the background thread commences.
+ */
+public abstract class AuthenticatedUserTask<ResultT> extends RoboAsyncTask<ResultT> {
+
+    @Inject
+    private ContextScope contextScope;
+
+    @Inject
+    private GitHubAccountScope gitHubAccountScope;
+
+    @Inject
+    private Activity activity;
+
+    protected AuthenticatedUserTask(Context context) {
+        super(context);
+    }
+
+    public AuthenticatedUserTask(Context context, Executor executor) {
+        super(context, executor);
+    }
+
+    @Override
+    public final ResultT call() throws Exception {
+        gitHubAccountScope.enterWith(activity);
+        try {
+            contextScope.enter(getContext());
+            try {
+                return run();
+            } finally {
+                contextScope.exit(getContext());
+            }
+        } finally {
+            gitHubAccountScope.exit();
+        }
+    }
+
+    protected abstract ResultT run() throws Exception;
+}

--- a/app/src/main/java/com/github/mobile/android/authenticator/GitHubAccount.java
+++ b/app/src/main/java/com/github/mobile/android/authenticator/GitHubAccount.java
@@ -8,4 +8,9 @@ public class GitHubAccount {
         this.username = username;
         this.password = password;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[" + username + "]";
+    }
 }

--- a/app/src/main/java/com/github/mobile/android/authenticator/GitHubAuthenticatorActivity.java
+++ b/app/src/main/java/com/github/mobile/android/authenticator/GitHubAuthenticatorActivity.java
@@ -60,9 +60,6 @@ public class GitHubAuthenticatorActivity extends RoboAccountAuthenticatorActivit
     LeavingBlankTextFieldWarner leavingBlankTextFieldWarner;
     private TextWatcher watcher = validationTextWatcher();
 
-    @Inject
-    private GitHubClient client;
-
     private RoboAsyncTask<User> authenticationTask;
     private String mAuthtoken;
     private String mAuthtokenType;
@@ -182,6 +179,7 @@ public class GitHubAuthenticatorActivity extends RoboAccountAuthenticatorActivit
 
             authenticationTask = new RoboAsyncTask<User>(this) {
                 public User call() throws Exception {
+                    GitHubClient client = new GitHubClient();
                     client.setCredentials(mUsername, mPassword);
 
                     return new UserService(client).getUser();

--- a/app/src/main/java/com/github/mobile/android/gist/DeleteGistTask.java
+++ b/app/src/main/java/com/github/mobile/android/gist/DeleteGistTask.java
@@ -7,18 +7,18 @@ import android.app.ProgressDialog;
 import android.widget.Toast;
 
 import com.github.mobile.android.R.string;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 import com.google.inject.Inject;
 
 import org.eclipse.egit.github.core.Gist;
 import org.eclipse.egit.github.core.service.GistService;
 
 import roboguice.inject.ContextScopedProvider;
-import roboguice.util.RoboAsyncTask;
 
 /**
  * Async task to delete a Gist
  */
-public class DeleteGistTask extends RoboAsyncTask<Gist> {
+public class DeleteGistTask extends AuthenticatedUserTask<Gist> {
 
     private final String id;
 
@@ -60,7 +60,7 @@ public class DeleteGistTask extends RoboAsyncTask<Gist> {
     }
 
     @Override
-    public Gist call() throws Exception {
+    public Gist run() throws Exception {
         serviceProvider.get(getContext()).deleteGist(id);
         return null;
     }

--- a/app/src/main/java/com/github/mobile/android/gist/GistFileFragment.java
+++ b/app/src/main/java/com/github/mobile/android/gist/GistFileFragment.java
@@ -11,6 +11,7 @@ import android.webkit.WebView;
 import com.github.mobile.android.R.id;
 import com.github.mobile.android.R.layout;
 import com.github.mobile.android.R.string;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 import com.github.mobile.android.util.ErrorHelper;
 import com.github.mobile.android.util.SourceEditor;
 import com.github.rtyley.android.sherlock.roboguice.fragment.RoboSherlockFragment;
@@ -24,7 +25,6 @@ import org.eclipse.egit.github.core.GistFile;
 
 import roboguice.inject.InjectExtra;
 import roboguice.inject.InjectView;
-import roboguice.util.RoboAsyncTask;
 
 /**
  * Fragment to display the content of a file in a Gist
@@ -55,8 +55,8 @@ public class GistFileFragment extends RoboSherlockFragment {
     }
 
     private void loadSource() {
-        new RoboAsyncTask<GistFile>(getActivity()) {
-            public GistFile call() throws Exception {
+        new AuthenticatedUserTask<GistFile>(getActivity()) {
+            public GistFile run() throws Exception {
                 gist = store.refreshGist(gistId);
                 Map<String, GistFile> files = gist.getFiles();
                 if (files == null)

--- a/app/src/main/java/com/github/mobile/android/gist/GistFragment.java
+++ b/app/src/main/java/com/github/mobile/android/gist/GistFragment.java
@@ -30,6 +30,7 @@ import com.github.mobile.android.R.layout;
 import com.github.mobile.android.R.menu;
 import com.github.mobile.android.R.string;
 import com.github.mobile.android.RefreshAnimation;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 import com.github.mobile.android.comment.CommentViewHolder;
 import com.github.mobile.android.comment.CreateCommentActivity;
 import com.github.mobile.android.core.gist.FullGist;
@@ -54,7 +55,6 @@ import org.eclipse.egit.github.core.service.GistService;
 
 import roboguice.inject.ContextScopedProvider;
 import roboguice.inject.InjectView;
-import roboguice.util.RoboAsyncTask;
 
 /**
  * Activity to display an existing Gist
@@ -210,9 +210,9 @@ public class GistFragment extends RoboSherlockFragment implements OnItemClickLis
 
     private void starGist() {
         Toast.makeText(getActivity().getApplicationContext(), getString(string.starring_gist), LENGTH_LONG).show();
-        new RoboAsyncTask<Gist>(getActivity()) {
+        new AuthenticatedUserTask<Gist>(getActivity()) {
 
-            public Gist call() throws Exception {
+            public Gist run() throws Exception {
                 gistServiceProvider.get(getContext()).starGist(gistId);
                 starred = true;
                 return null;
@@ -226,9 +226,9 @@ public class GistFragment extends RoboSherlockFragment implements OnItemClickLis
 
     private void unstarGist() {
         Toast.makeText(getActivity().getApplicationContext(), getString(string.unstarring_gist), LENGTH_LONG).show();
-        new RoboAsyncTask<Gist>(getActivity()) {
+        new AuthenticatedUserTask<Gist>(getActivity()) {
 
-            public Gist call() throws Exception {
+            public Gist run() throws Exception {
                 gistServiceProvider.get(getActivity()).unstarGist(gistId);
                 starred = false;
                 return null;
@@ -257,9 +257,9 @@ public class GistFragment extends RoboSherlockFragment implements OnItemClickLis
         progress.setMessage(getString(string.creating_comment));
         progress.setIndeterminate(true);
         progress.show();
-        new RoboAsyncTask<Comment>(getActivity()) {
+        new AuthenticatedUserTask<Comment>(getActivity()) {
 
-            public Comment call() throws Exception {
+            public Comment run() throws Exception {
                 return gistServiceProvider.get(getActivity()).createComment(gistId, comment);
             }
 
@@ -314,9 +314,9 @@ public class GistFragment extends RoboSherlockFragment implements OnItemClickLis
     }
 
     private void refreshGist() {
-        new RoboAsyncTask<FullGist>(getActivity(), executor) {
+        new AuthenticatedUserTask<FullGist>(getActivity(), executor) {
 
-            public FullGist call() throws Exception {
+            public FullGist run() throws Exception {
                 Gist gist = store.refreshGist(gistId);
                 GistService gistService = service.get(getContext());
                 List<Comment> comments;

--- a/app/src/main/java/com/github/mobile/android/gist/RandomGistTask.java
+++ b/app/src/main/java/com/github/mobile/android/gist/RandomGistTask.java
@@ -7,6 +7,7 @@ import android.widget.Toast;
 
 import com.github.mobile.android.R.string;
 import com.github.mobile.android.RequestCodes;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 import com.google.inject.Inject;
 
 import java.util.Collection;
@@ -16,12 +17,11 @@ import org.eclipse.egit.github.core.client.PageIterator;
 import org.eclipse.egit.github.core.service.GistService;
 
 import roboguice.inject.ContextScopedProvider;
-import roboguice.util.RoboAsyncTask;
 
 /**
  * Task to open a random Gist
  */
-public class RandomGistTask extends RoboAsyncTask<Gist> {
+public class RandomGistTask extends AuthenticatedUserTask<Gist> {
 
     private ProgressDialog progress;
 
@@ -61,7 +61,8 @@ public class RandomGistTask extends RoboAsyncTask<Gist> {
         execute();
     }
 
-    public Gist call() throws Exception {
+    @Override
+    protected Gist run() throws Exception {
         GistService service = serviceProvider.get(getContext());
         GistStore store = storeProvider.get(getContext());
 

--- a/app/src/main/java/com/github/mobile/android/gist/ShareGistActivity.java
+++ b/app/src/main/java/com/github/mobile/android/gist/ShareGistActivity.java
@@ -18,6 +18,7 @@ import com.github.mobile.android.R.layout;
 import com.github.mobile.android.R.menu;
 import com.github.mobile.android.R.string;
 import com.github.mobile.android.TextWatcherAdapter;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 import com.github.rtyley.android.sherlock.roboguice.activity.RoboSherlockFragmentActivity;
 import com.google.inject.Inject;
 
@@ -29,7 +30,6 @@ import org.eclipse.egit.github.core.service.GistService;
 
 import roboguice.inject.ContextScopedProvider;
 import roboguice.inject.InjectView;
-import roboguice.util.RoboAsyncTask;
 
 /**
  * Activity to share a text selection as a public or private Gist
@@ -111,9 +111,9 @@ public class ShareGistActivity extends RoboSherlockFragmentActivity {
         final ProgressDialog progress = new ProgressDialog(this);
         progress.setMessage(getString(string.creating_gist));
         progress.show();
-        new RoboAsyncTask<Gist>(this) {
+        new AuthenticatedUserTask<Gist>(this) {
 
-            public Gist call() throws Exception {
+            public Gist run() throws Exception {
                 Gist gist = new Gist();
                 gist.setDescription(description);
                 gist.setPublic(isPublic);

--- a/app/src/main/java/com/github/mobile/android/guice/GitHubAccountScope.java
+++ b/app/src/main/java/com/github/mobile/android/guice/GitHubAccountScope.java
@@ -1,0 +1,118 @@
+package com.github.mobile.android.guice;
+
+import static android.accounts.AccountManager.KEY_ACCOUNT_NAME;
+import static com.github.mobile.android.authenticator.Constants.GITHUB_ACCOUNT_TYPE;
+import static com.google.common.base.Preconditions.checkState;
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.app.Activity;
+import android.os.Bundle;
+import android.util.Log;
+
+import com.github.mobile.android.authenticator.GitHubAccount;
+import com.google.common.base.Function;
+import com.google.common.collect.MapMaker;
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.OutOfScopeException;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+
+/**
+ * Custom Guice-scope that makes an authenticated GitHub account available,
+ * by enforcing that the user is logged in before proceeding.
+ */
+public class GitHubAccountScope extends ScopeBase {
+
+    private final static String TAG = "GitHubAccountScope";
+
+    private final static Key<GitHubAccount> GITHUB_ACCOUNT_KEY = Key.get(GitHubAccount.class);
+
+    public static Module module() {
+        return new AbstractModule() {
+            public void configure() {
+                GitHubAccountScope scope = new GitHubAccountScope();
+
+                bind(GitHubAccountScope.class).toInstance(scope);
+
+                bind(GITHUB_ACCOUNT_KEY).toProvider(GitHubAccountScope.<GitHubAccount>seededKeyProvider()).in(scope);
+            }
+        };
+    }
+
+    private final ThreadLocal<GitHubAccount> currentAccount = new ThreadLocal<GitHubAccount>();
+
+    private final Map<GitHubAccount, Map<Key<?>, Object>> repoScopeMaps = new MapMaker().
+            makeComputingMap(new Function<GitHubAccount, Map<Key<?>, Object>>() {
+                public Map<Key<?>, Object> apply(GitHubAccount account) {
+                    ConcurrentMap<Key<?>, Object> accountScopeMap = new MapMaker().makeMap();
+                    accountScopeMap.put(GITHUB_ACCOUNT_KEY, account);
+                    return accountScopeMap;
+                }
+            });
+
+    /**
+     * Enters scope once we've ensured the user has a valid account.
+     */
+    public void enterWith(Activity activityUsedToStartLoginProcess) {
+        AccountManager accountManager = AccountManager.get(activityUsedToStartLoginProcess);
+        Account account = demandCurrentAccount(accountManager, activityUsedToStartLoginProcess);
+        enterWith(account, accountManager);
+    }
+
+    /**
+     * Enters scope using a GitHubAccount derived from the supplied account
+     */
+    public void enterWith(Account account, AccountManager accountManager) {
+        enterWith(new GitHubAccount(account.name, accountManager.getPassword(account)));
+    }
+
+    public void enterWith(GitHubAccount account) {
+        Log.d(TAG, "entering scope with " + account);
+        checkState(currentAccount.get() == null, "A scoping block is already in progress");
+        currentAccount.set(account);
+    }
+
+    public void exit() {
+        Log.d(TAG, "exiting scope");
+        checkState(currentAccount.get() != null, "No scoping block in progress");
+        currentAccount.remove();
+    }
+
+    @Override
+    protected <T> Map<Key<?>, Object> getScopedObjectMap(Key<T> key) {
+        GitHubAccount account = currentAccount.get();
+        if (account == null) {
+            throw new OutOfScopeException("Cannot access " + key + " outside of a scoping block");
+        }
+        return repoScopeMaps.get(account);
+    }
+
+    private Account demandCurrentAccount(AccountManager accountManager, Activity activityUsedToStartLoginProcess) {
+        Account[] accounts;
+        Log.d(TAG, "Getting current account...");
+        try {
+            while ((accounts = accountManager.
+                    getAccountsByTypeAndFeatures(GITHUB_ACCOUNT_TYPE, null, null, null).getResult()).length == 0) {
+                Log.d(TAG, "Currently zero GitHub accounts... activity=" + activityUsedToStartLoginProcess);
+                if (activityUsedToStartLoginProcess == null)
+                    throw new RuntimeException("Can't create new GitHub account - no activity available");
+
+                Bundle result = accountManager.addAccount(GITHUB_ACCOUNT_TYPE, null, null, null,
+                        activityUsedToStartLoginProcess, null, null).getResult();
+
+                Log.i(TAG, "Added account " + result.getString(KEY_ACCOUNT_NAME));
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Problem getting a Github account...", e);
+            throw new RuntimeException(e);
+        }
+
+        Account account = accounts[0];
+        Log.d(TAG, "Returning account " + account.name);
+        return account;
+    }
+}

--- a/app/src/main/java/com/github/mobile/android/guice/ScopeBase.java
+++ b/app/src/main/java/com/github/mobile/android/guice/ScopeBase.java
@@ -1,0 +1,48 @@
+package com.github.mobile.android.guice;
+
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+
+import java.util.Map;
+
+public abstract class ScopeBase implements Scope {
+
+    private static final Provider<Object> SEEDED_KEY_PROVIDER = new Provider<Object>() {
+        public Object get() {
+            throw new IllegalStateException(
+                    "If you got here then it means that"
+                            + " your code asked for scoped object which should have been"
+                            + " explicitly seeded in this scope, but was not.");
+        }
+    };
+
+    /**
+     * Returns a provider that always throws an exception complaining that the
+     * object in question must be seeded before it can be injected.
+     *
+     * @return typed provider
+     */
+    @SuppressWarnings({ "unchecked" })
+    public static <T> Provider<T> seededKeyProvider() {
+        return (Provider<T>) SEEDED_KEY_PROVIDER;
+    }
+
+    public <T> Provider<T> scope(final Key<T> key, final Provider<T> unscoped) {
+        return new Provider<T>() {
+            public T get() {
+                Map<Key<?>, Object> scopedObjects = getScopedObjectMap(key);
+
+                @SuppressWarnings("unchecked")
+                T current = (T) scopedObjects.get(key);
+                if (current == null && !scopedObjects.containsKey(key)) {
+                    current = unscoped.get();
+                    scopedObjects.put(key, current);
+                }
+                return current;
+            }
+        };
+    }
+
+    protected abstract <T> Map<Key<?>, Object> getScopedObjectMap(Key<T> key);
+}

--- a/app/src/main/java/com/github/mobile/android/issue/AssigneeDialog.java
+++ b/app/src/main/java/com/github/mobile/android/issue/AssigneeDialog.java
@@ -17,7 +17,7 @@ import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.User;
 import org.eclipse.egit.github.core.service.CollaboratorService;
 
-import roboguice.util.RoboAsyncTask;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 
 /**
  * Dialog helper to display a list of assignees to select one from
@@ -54,9 +54,9 @@ public class AssigneeDialog {
         final ProgressDialog loader = new ProgressDialog(activity);
         loader.setMessage("Loading Collaborators...");
         loader.show();
-        new RoboAsyncTask<List<User>>(activity) {
+        new AuthenticatedUserTask<List<User>>(activity) {
 
-            public List<User> call() throws Exception {
+            public List<User> run() throws Exception {
                 List<User> users = service.getCollaborators(repository);
                 Map<String, User> loadedCollaborators = new TreeMap<String, User>(new Comparator<String>() {
 

--- a/app/src/main/java/com/github/mobile/android/issue/CreateIssueActivity.java
+++ b/app/src/main/java/com/github/mobile/android/issue/CreateIssueActivity.java
@@ -42,7 +42,7 @@ import org.eclipse.egit.github.core.service.MilestoneService;
 
 import roboguice.inject.InjectExtra;
 import roboguice.inject.InjectView;
-import roboguice.util.RoboAsyncTask;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 
 /**
  * Activity to create a new issue
@@ -237,9 +237,9 @@ public class CreateIssueActivity extends DialogFragmentActivity {
         progress.show();
         newIssue.setTitle(titleText.getText().toString());
         newIssue.setBody(bodyText.getText().toString());
-        new RoboAsyncTask<Issue>(this) {
+        new AuthenticatedUserTask<Issue>(this) {
 
-            public Issue call() throws Exception {
+            public Issue run() throws Exception {
                 return store.addIssue(service.createIssue(repoOwner, repoName, newIssue));
             }
 

--- a/app/src/main/java/com/github/mobile/android/issue/DashboardIssueFragment.java
+++ b/app/src/main/java/com/github/mobile/android/issue/DashboardIssueFragment.java
@@ -7,10 +7,10 @@ import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.ListView;
 
-import com.github.mobile.android.AsyncLoader;
 import com.github.mobile.android.R.id;
 import com.github.mobile.android.R.layout;
 import com.github.mobile.android.R.string;
+import com.github.mobile.android.async.AuthenticatedUserLoader;
 import com.github.mobile.android.ui.fragments.ListLoadingFragment;
 import com.github.mobile.android.util.AvatarHelper;
 import com.google.inject.Inject;
@@ -78,9 +78,9 @@ public class DashboardIssueFragment extends ListLoadingFragment<Issue> {
 
     @Override
     public Loader<List<Issue>> onCreateLoader(int id, Bundle args) {
-        return new AsyncLoader<List<Issue>>(getActivity()) {
+        return new AuthenticatedUserLoader<List<Issue>>(getActivity()) {
 
-            public List<Issue> loadInBackground() {
+            public List<Issue> load() {
                 try {
                     hasMore = pager.next();
                 } catch (final IOException e) {

--- a/app/src/main/java/com/github/mobile/android/issue/FilterListFragment.java
+++ b/app/src/main/java/com/github/mobile/android/issue/FilterListFragment.java
@@ -6,8 +6,8 @@ import android.support.v4.content.Loader;
 import android.view.View;
 import android.widget.ListView;
 
+import com.github.mobile.android.async.AuthenticatedUserLoader;
 import com.github.mobile.android.persistence.AccountDataManager;
-import com.github.mobile.android.AsyncLoader;
 import com.github.mobile.android.R.layout;
 import com.github.mobile.android.R.string;
 import com.github.mobile.android.ui.fragments.ListLoadingFragment;
@@ -36,9 +36,9 @@ public class FilterListFragment extends ListLoadingFragment<IssueFilter> {
 
     @Override
     public Loader<List<IssueFilter>> onCreateLoader(int id, Bundle args) {
-        return new AsyncLoader<List<IssueFilter>>(getActivity()) {
+        return new AuthenticatedUserLoader<List<IssueFilter>>(getActivity()) {
 
-            public List<IssueFilter> loadInBackground() {
+            public List<IssueFilter> load() {
                 List<IssueFilter> filters = newArrayList(cache.getIssueFilters());
                 Collections.sort(filters, new Comparator<IssueFilter>() {
 

--- a/app/src/main/java/com/github/mobile/android/issue/IssuesFragment.java
+++ b/app/src/main/java/com/github/mobile/android/issue/IssuesFragment.java
@@ -15,9 +15,9 @@ import android.widget.AdapterView.OnItemClickListener;
 import android.widget.Button;
 import android.widget.ListView;
 
-import com.github.mobile.android.AsyncLoader;
 import com.github.mobile.android.R.layout;
 import com.github.mobile.android.R.string;
+import com.github.mobile.android.async.AuthenticatedUserLoader;
 import com.github.mobile.android.ui.fragments.ListLoadingFragment;
 import com.github.mobile.android.util.AvatarHelper;
 import com.google.inject.Inject;
@@ -173,10 +173,10 @@ public class IssuesFragment extends ListLoadingFragment<Issue> {
                     }
                 });
         final IssuePager[] loaderPagers = pagers.toArray(new IssuePager[pagers.size()]);
-        return new AsyncLoader<List<Issue>>(getActivity()) {
+        return new AuthenticatedUserLoader<List<Issue>>(getActivity()) {
 
             @Override
-            public List<Issue> loadInBackground() {
+            public List<Issue> load() {
                 hasMore = false;
                 final List<Issue> all = newArrayList();
                 boolean error = false;

--- a/app/src/main/java/com/github/mobile/android/issue/LabelsDialog.java
+++ b/app/src/main/java/com/github/mobile/android/issue/LabelsDialog.java
@@ -19,7 +19,7 @@ import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.Label;
 import org.eclipse.egit.github.core.service.LabelService;
 
-import roboguice.util.RoboAsyncTask;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 
 /**
  * Dialog helper to display a list of possibly selected issue labels
@@ -56,9 +56,9 @@ public class LabelsDialog {
         final ProgressDialog loader = new ProgressDialog(activity);
         loader.setMessage("Loading Labels...");
         loader.show();
-        new RoboAsyncTask<List<Label>>(activity) {
+        new AuthenticatedUserTask<List<Label>>(activity) {
 
-            public List<Label> call() throws Exception {
+            public List<Label> run() throws Exception {
                 List<Label> repositoryLabels = service.getLabels(repository);
                 Map<String, Label> loadedLabels = new TreeMap<String, Label>(new Comparator<String>() {
 

--- a/app/src/main/java/com/github/mobile/android/issue/MilestoneDialog.java
+++ b/app/src/main/java/com/github/mobile/android/issue/MilestoneDialog.java
@@ -16,7 +16,7 @@ import org.eclipse.egit.github.core.Milestone;
 import org.eclipse.egit.github.core.service.IssueService;
 import org.eclipse.egit.github.core.service.MilestoneService;
 
-import roboguice.util.RoboAsyncTask;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 
 /**
  * Dialog helper to display a list of milestones to select one from
@@ -62,9 +62,9 @@ public class MilestoneDialog {
         final ProgressDialog loader = new ProgressDialog(activity);
         loader.setMessage("Loading Milestones...");
         loader.show();
-        new RoboAsyncTask<List<Milestone>>(activity) {
+        new AuthenticatedUserTask<List<Milestone>>(activity) {
 
-            public List<Milestone> call() throws Exception {
+            public List<Milestone> run() throws Exception {
                 repositoryMilestones = newArrayList();
                 repositoryMilestones.addAll(service.getMilestones(repository, IssueService.STATE_OPEN));
                 repositoryMilestones.addAll(service.getMilestones(repository, IssueService.STATE_CLOSED));

--- a/app/src/main/java/com/github/mobile/android/issue/ViewIssueActivity.java
+++ b/app/src/main/java/com/github/mobile/android/issue/ViewIssueActivity.java
@@ -65,7 +65,7 @@ import org.eclipse.egit.github.core.service.MilestoneService;
 import roboguice.inject.ContextScopedProvider;
 import roboguice.inject.InjectExtra;
 import roboguice.inject.InjectView;
-import roboguice.util.RoboAsyncTask;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 
 /**
  * Activity to view a specific issue
@@ -241,9 +241,9 @@ public class ViewIssueActivity extends DialogFragmentActivity {
             list.addHeaderView(loadingView);
             list.setAdapter(new ArrayAdapter<Comment>(this, layout.comment_view_item));
         }
-        new RoboAsyncTask<FullIssue>(this) {
+        new AuthenticatedUserTask<FullIssue>(this) {
 
-            public FullIssue call() throws Exception {
+            public FullIssue run() throws Exception {
                 Issue issue = store.refreshIssue(repositoryId, issueNumber);
                 if (!destroyed)
                     setBeamMessage(ViewIssueActivity.this, "repo.issue", issue);
@@ -374,9 +374,9 @@ public class ViewIssueActivity extends DialogFragmentActivity {
         progress.setMessage("Creating comment...");
         progress.setIndeterminate(true);
         progress.show();
-        new RoboAsyncTask<Comment>(this) {
+        new AuthenticatedUserTask<Comment>(this) {
 
-            public Comment call() throws Exception {
+            public Comment run() throws Exception {
                 return service.get(ViewIssueActivity.this).createComment(repositoryOwner, repository, issueNumber,
                         comment);
             }
@@ -434,9 +434,9 @@ public class ViewIssueActivity extends DialogFragmentActivity {
             progress.setMessage("Reopening issue...");
         progress.setIndeterminate(true);
         progress.show();
-        new RoboAsyncTask<Issue>(this) {
+        new AuthenticatedUserTask<Issue>(this) {
 
-            public Issue call() throws Exception {
+            public Issue run() throws Exception {
                 Issue editedIssue = new Issue();
                 editedIssue.setNumber(issueNumber);
                 if (close)
@@ -465,9 +465,9 @@ public class ViewIssueActivity extends DialogFragmentActivity {
         progress.setMessage("Updating labels...");
         progress.setIndeterminate(true);
         progress.show();
-        new RoboAsyncTask<Issue>(this) {
+        new AuthenticatedUserTask<Issue>(this) {
 
-            public Issue call() throws Exception {
+            public Issue run() throws Exception {
                 Issue editedIssue = new Issue();
                 editedIssue.setNumber(issueNumber);
                 List<Label> issueLabels = new ArrayList<Label>(labels.length);
@@ -502,9 +502,9 @@ public class ViewIssueActivity extends DialogFragmentActivity {
         progress.setMessage("Updating milestone...");
         progress.setIndeterminate(true);
         progress.show();
-        new RoboAsyncTask<Issue>(this) {
+        new AuthenticatedUserTask<Issue>(this) {
 
-            public Issue call() throws Exception {
+            public Issue run() throws Exception {
                 Issue editedIssue = new Issue();
                 editedIssue.setNumber(issueNumber);
                 editedIssue.setMilestone(new Milestone().setNumber(milestoneNumber));
@@ -530,9 +530,9 @@ public class ViewIssueActivity extends DialogFragmentActivity {
         progress.setMessage("Updating assignee...");
         progress.setIndeterminate(true);
         progress.show();
-        new RoboAsyncTask<Issue>(this) {
+        new AuthenticatedUserTask<Issue>(this) {
 
-            public Issue call() throws Exception {
+            public Issue run() throws Exception {
                 Issue editedIssue = new Issue();
                 editedIssue.setAssignee(new User().setLogin(user != null ? user : ""));
                 editedIssue.setNumber(issueNumber);
@@ -558,9 +558,9 @@ public class ViewIssueActivity extends DialogFragmentActivity {
         progress.setMessage("Updating title & description...");
         progress.setIndeterminate(true);
         progress.show();
-        new RoboAsyncTask<Issue>(this) {
+        new AuthenticatedUserTask<Issue>(this) {
 
-            public Issue call() throws Exception {
+            public Issue run() throws Exception {
                 Issue editedIssue = new Issue();
                 editedIssue.setTitle(title);
                 editedIssue.setBody(body);

--- a/app/src/main/java/com/github/mobile/android/persistence/AccountDataManager.java
+++ b/app/src/main/java/com/github/mobile/android/persistence/AccountDataManager.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executors;
 import org.eclipse.egit.github.core.Repository;
 import org.eclipse.egit.github.core.User;
 
-import roboguice.util.RoboAsyncTask;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 
 /**
  * Manager cache for an account
@@ -198,9 +198,9 @@ public class AccountDataManager {
      * @param requestFuture
      */
     public void getIssueFilters(final RequestFuture<Collection<IssueFilter>> requestFuture) {
-        new RoboAsyncTask<Collection<IssueFilter>>(context, EXECUTOR) {
+        new AuthenticatedUserTask<Collection<IssueFilter>>(context, EXECUTOR) {
 
-            public Collection<IssueFilter> call() throws Exception {
+            public Collection<IssueFilter> run() throws Exception {
                 return getIssueFilters();
             }
 
@@ -235,9 +235,9 @@ public class AccountDataManager {
      * @param requestFuture
      */
     public void addIssueFilter(final IssueFilter filter, final RequestFuture<IssueFilter> requestFuture) {
-        new RoboAsyncTask<IssueFilter>(context, EXECUTOR) {
+        new AuthenticatedUserTask<IssueFilter>(context, EXECUTOR) {
 
-            public IssueFilter call() throws Exception {
+            public IssueFilter run() throws Exception {
                 addIssueFilter(filter);
                 return filter;
             }
@@ -274,9 +274,9 @@ public class AccountDataManager {
      * @param requestFuture
      */
     public void removeIssueFilter(final IssueFilter filter, final RequestFuture<IssueFilter> requestFuture) {
-        new RoboAsyncTask<IssueFilter>(context, EXECUTOR) {
+        new AuthenticatedUserTask<IssueFilter>(context, EXECUTOR) {
 
-            public IssueFilter call() throws Exception {
+            public IssueFilter run() throws Exception {
                 removeIssueFilter(filter);
                 return filter;
             }

--- a/app/src/main/java/com/github/mobile/android/persistence/AllReposForUserOrOrg.java
+++ b/app/src/main/java/com/github/mobile/android/persistence/AllReposForUserOrOrg.java
@@ -5,7 +5,9 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 
+import com.github.mobile.android.authenticator.GitHubAccount;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.google.inject.assistedinject.Assisted;
 
 import java.io.IOException;
@@ -23,11 +25,14 @@ public class AllReposForUserOrOrg implements PersistableResource<Repository> {
 
     private final User userOrOrg;
     private final RepositoryService repos;
+    private final Provider<GitHubAccount> gitHubAccountProvider;
 
     @Inject
-    public AllReposForUserOrOrg(@Assisted User userOrOrg, RepositoryService repos) {
+    public AllReposForUserOrOrg(@Assisted User userOrOrg, RepositoryService repos,
+                                Provider<GitHubAccount> gitHubAccountProvider) {
         this.userOrOrg = userOrOrg;
         this.repos = repos;
+        this.gitHubAccountProvider = gitHubAccountProvider;
     }
 
     @Override
@@ -77,10 +82,14 @@ public class AllReposForUserOrOrg implements PersistableResource<Repository> {
 
     @Override
     public List<Repository> request() throws IOException {
-        if (userOrOrg.getLogin().equals(repos.getClient().getUser()))
+        if (userOrOrgIsAuthenticatedUser())
             return repos.getRepositories();
         else
             return repos.getOrgRepositories(userOrOrg.getLogin());
+    }
+
+    private boolean userOrOrgIsAuthenticatedUser() {
+        return userOrOrg.getLogin().equals(gitHubAccountProvider.get().username);
     }
 
     @Override

--- a/app/src/main/java/com/github/mobile/android/repo/OrgListFragment.java
+++ b/app/src/main/java/com/github/mobile/android/repo/OrgListFragment.java
@@ -1,7 +1,8 @@
 package com.github.mobile.android.repo;
 
-import static android.util.Log.DEBUG;
+import static android.util.Log.WARN;
 import static com.actionbarsherlock.view.MenuItem.SHOW_AS_ACTION_NEVER;
+import static java.util.Collections.sort;
 import android.os.Bundle;
 import android.support.v4.content.Loader;
 import android.util.Log;
@@ -10,7 +11,7 @@ import android.widget.ListView;
 
 import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
-import com.github.mobile.android.guice.RoboAsyncLoader;
+import com.github.mobile.android.async.AuthenticatedUserLoader;
 import com.github.mobile.android.persistence.AccountDataManager;
 import com.github.mobile.android.R.id;
 import com.github.mobile.android.R.layout;
@@ -18,24 +19,23 @@ import com.github.mobile.android.R.string;
 import com.github.mobile.android.ui.fragments.ListLoadingFragment;
 import com.github.mobile.android.util.AvatarHelper;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.madgag.android.listviews.ReflectiveHolderFactory;
 import com.madgag.android.listviews.ViewHoldingListAdapter;
 import com.madgag.android.listviews.ViewInflator;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import org.eclipse.egit.github.core.User;
-import org.eclipse.egit.github.core.client.GitHubClient;
 
 /**
  * Fragment to load a list of GitHub organizations
  */
-public class OrgListFragment extends ListLoadingFragment<User> implements Comparator<User> {
+public class OrgListFragment extends ListLoadingFragment<User> {
 
-    private static final String TAG = "OLF";
+    private static final String TAG = "GH.OLF";
 
     @Inject
     private AccountDataManager cache;
@@ -43,21 +43,20 @@ public class OrgListFragment extends ListLoadingFragment<User> implements Compar
     @Inject
     private AvatarHelper avatarHelper;
 
-    @Inject
-    private GitHubClient client;
-
     @Override
     public Loader<List<User>> onCreateLoader(int id, Bundle args) {
-        return new RoboAsyncLoader<List<User>>(getActivity()) {
+        return new AuthenticatedUserLoader<List<User>>(getActivity()) {
+            @Inject Provider<UserComparator> userComparatorProvider;
 
-            public List<User> loadInBackgroundWithContextScope() {
+            public List<User> load() {
+                Log.d(TAG, "Going to load organizations");
                 try {
                     List<User> orgs = cache.getOrgs();
-                    Collections.sort(orgs, OrgListFragment.this);
+                    sort(orgs, userComparatorProvider.get());
                     return orgs;
                 } catch (final IOException e) {
-                    if (Log.isLoggable(TAG, DEBUG))
-                        Log.d(TAG, "Exception loading organizations", e);
+                    if (Log.isLoggable(TAG, WARN))
+                        Log.w(TAG, "Exception loading organizations", e);
 
                     showError(e, string.error_orgs_load);
 
@@ -85,13 +84,4 @@ public class OrgListFragment extends ListLoadingFragment<User> implements Compar
         startActivity(RepoBrowseActivity.createIntent(user));
     }
 
-    @Override
-    public int compare(final User lhs, final User rhs) {
-        if (lhs.getLogin().equals(client.getUser()))
-            return -1;
-        if (rhs.getLogin().equals(client.getUser()))
-            return 1;
-
-        return lhs.getLogin().compareToIgnoreCase(rhs.getLogin());
-    }
 }

--- a/app/src/main/java/com/github/mobile/android/repo/RepoListFragment.java
+++ b/app/src/main/java/com/github/mobile/android/repo/RepoListFragment.java
@@ -11,7 +11,7 @@ import android.view.View;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ListView;
 
-import com.github.mobile.android.guice.RoboAsyncLoader;
+import com.github.mobile.android.async.AuthenticatedUserLoader;
 import com.github.mobile.android.persistence.AccountDataManager;
 import com.github.mobile.android.R.layout;
 import com.github.mobile.android.R.string;
@@ -99,10 +99,11 @@ public class RepoListFragment extends ListLoadingFragment<Repository> {
 
     @Override
     public Loader<List<Repository>> onCreateLoader(int id, Bundle args) {
-        return new RoboAsyncLoader<List<Repository>>(getActivity()) {
+        return new AuthenticatedUserLoader<List<Repository>>(getActivity()) {
 
-            public List<Repository> loadInBackgroundWithContextScope() {
+            public List<Repository> load() {
                 try {
+                    Log.d(TAG, "Going to load repos for "+user.getLogin());
                     List<Repository> repos = newArrayList(cache.getRepos(user));
                     Collections.sort(repos, new Comparator<Repository>() {
 

--- a/app/src/main/java/com/github/mobile/android/repo/SearchRepoListFragment.java
+++ b/app/src/main/java/com/github/mobile/android/repo/SearchRepoListFragment.java
@@ -9,6 +9,7 @@ import com.github.mobile.android.IRepositorySearch;
 import com.github.mobile.android.R.layout;
 import com.github.mobile.android.R.string;
 import com.github.mobile.android.ThrowableLoader;
+import com.github.mobile.android.async.AuthenticatedUserTask;
 import com.github.mobile.android.issue.IssueBrowseActivity;
 import com.github.mobile.android.ui.fragments.ListLoadingFragment;
 import com.google.inject.Inject;
@@ -21,8 +22,6 @@ import java.util.List;
 import org.eclipse.egit.github.core.Repository;
 import org.eclipse.egit.github.core.SearchRepository;
 import org.eclipse.egit.github.core.service.RepositoryService;
-
-import roboguice.util.RoboAsyncTask;
 
 /**
  * Fragment to display a list of {@link Repository} instances
@@ -56,9 +55,9 @@ public class SearchRepoListFragment extends ListLoadingFragment<SearchRepository
     @Override
     public void onListItemClick(ListView l, View v, int position, long id) {
         final SearchRepository result = (SearchRepository) l.getItemAtPosition(position);
-        new RoboAsyncTask<Repository>(getActivity()) {
+        new AuthenticatedUserTask<Repository>(getActivity()) {
 
-            public Repository call() throws Exception {
+            public Repository run() throws Exception {
                 return repos.getRepository(result);
             }
 

--- a/app/src/main/java/com/github/mobile/android/repo/UserComparator.java
+++ b/app/src/main/java/com/github/mobile/android/repo/UserComparator.java
@@ -1,0 +1,33 @@
+package com.github.mobile.android.repo;
+
+import com.github.mobile.android.authenticator.GitHubAccount;
+import com.google.inject.Inject;
+
+import java.util.Comparator;
+
+import org.eclipse.egit.github.core.User;
+
+/**
+ * Sorts users and orgs in alphabetical order by username, but overriding this
+ * to put the currently authenticated user at the top of the list.
+ */
+class UserComparator implements Comparator<User> {
+
+    private final String currentUserLogin;
+
+    @Inject
+    public UserComparator(GitHubAccount gitHubAccount) {
+        currentUserLogin = gitHubAccount.username;
+    }
+
+    @Override
+    public int compare(User lhs, User rhs) {
+        String lhsLogin = lhs.getLogin(), rhsLogin = rhs.getLogin();
+        if (lhsLogin.equals(currentUserLogin))
+            return -1;
+        if (rhsLogin.equals(currentUserLogin))
+            return 1;
+
+        return lhsLogin.compareToIgnoreCase(rhsLogin);
+    }
+}

--- a/app/src/main/java/com/github/mobile/android/ui/fragments/IssuesFragment.java
+++ b/app/src/main/java/com/github/mobile/android/ui/fragments/IssuesFragment.java
@@ -10,7 +10,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.ListView;
 
-import com.github.mobile.android.AsyncLoader;
+import com.github.mobile.android.async.AuthenticatedUserLoader;
 import com.github.mobile.android.views.IssueViewHolder;
 import com.google.inject.Inject;
 import com.madgag.android.listviews.ViewHoldingListAdapter;
@@ -42,9 +42,9 @@ public class IssuesFragment extends ListLoadingFragment<Issue> {
 
     @Override
     public Loader<List<Issue>> onCreateLoader(int i, Bundle bundle) {
-        return new AsyncLoader<List<Issue>>(getActivity()) {
+        return new AuthenticatedUserLoader<List<Issue>>(getActivity()) {
             @Override
-            public List<Issue> loadInBackground() {
+            public List<Issue> load() {
                 Log.i(TAG, "started loadInBackground");
                 try {
                     return issueService.getIssues();

--- a/app/src/main/java/com/github/mobile/android/ui/fragments/PullRequestsFragment.java
+++ b/app/src/main/java/com/github/mobile/android/ui/fragments/PullRequestsFragment.java
@@ -6,15 +6,10 @@ import static com.madgag.android.listviews.ViewInflator.viewInflatorFor;
 import android.os.Bundle;
 import android.support.v4.content.Loader;
 import android.util.Log;
-import android.view.View;
-import android.widget.ListAdapter;
 
-import com.github.mobile.android.AsyncLoader;
+import com.github.mobile.android.async.AuthenticatedUserLoader;
 import com.github.mobile.android.views.PullRequestViewHolder;
 import com.google.inject.Inject;
-import com.madgag.android.listviews.ReflectiveHolderFactory;
-import com.madgag.android.listviews.ViewHolder;
-import com.madgag.android.listviews.ViewHolderFactory;
 import com.madgag.android.listviews.ViewHoldingListAdapter;
 
 import java.io.IOException;
@@ -39,9 +34,9 @@ public class PullRequestsFragment extends ListLoadingFragment<PullRequest> {
 
     @Override
     public Loader<List<PullRequest>> onCreateLoader(int i, Bundle bundle) {
-        return new AsyncLoader<List<PullRequest>>(getActivity()) {
+        return new AuthenticatedUserLoader<List<PullRequest>>(getActivity()) {
             @Override
-            public List<PullRequest> loadInBackground() {
+            public List<PullRequest> load() {
                 Log.i(TAG, "started loadInBackground");
                 try {
                     return pullRequestService.getPullRequests(RepositoryId.createFromId("rtyley/agit"), null);

--- a/app/src/main/java/com/github/mobile/android/util/LateAuthenticatedGitHubClient.java
+++ b/app/src/main/java/com/github/mobile/android/util/LateAuthenticatedGitHubClient.java
@@ -1,0 +1,44 @@
+package com.github.mobile.android.util;
+
+import android.util.Log;
+
+import com.github.mobile.android.authenticator.GitHubAccount;
+import com.google.inject.Provider;
+
+import java.net.HttpURLConnection;
+
+import org.eclipse.egit.github.core.client.GitHubClient;
+
+
+/**
+ * Addresses the problem with making sure the user is authenticated: that getting them to sign in is
+ * a process that will block, so you can't reasonably expect anything that occurs on the main thread
+ * to have a guaranteed reference to authenticated GitHub credentials.
+ * <p/>
+ * Fortunately, when people are doing network access it <em>has</em> to be on a background thread. We can
+ * enforce that these background threads have required the user to login, so at the point of <em>executing</em>
+ * the request, we will have credentials and can configure them on the request.
+ */
+public class LateAuthenticatedGitHubClient extends GitHubClient {
+
+    private final Provider<GitHubAccount> gitHubAccountProvider;
+    private static final String TAG = "LateAuthenticatedGitHubClient";
+
+    public LateAuthenticatedGitHubClient(Provider<GitHubAccount> gitHubAccountProvider) {
+        this.gitHubAccountProvider = gitHubAccountProvider;
+    }
+
+    public LateAuthenticatedGitHubClient(String hostname, Provider<GitHubAccount> gitHubAccountProvider) {
+        super(hostname);
+        this.gitHubAccountProvider = gitHubAccountProvider;
+    }
+
+    @Override
+    protected HttpURLConnection configureRequest(HttpURLConnection request) {
+        GitHubAccount ghAccount = gitHubAccountProvider.get();
+        Log.d(TAG, "Authenticating using " + ghAccount);
+        setCredentials(ghAccount.username, ghAccount.password); // must come *before* super to set credentials
+        super.configureRequest(request);
+        return request;
+    }
+}


### PR DESCRIPTION
The problem with making sure the user is authenticated is that getting
them to sign in is a process that will block, so you can't reasonably
expect anything that occurs on the main thread to have a guaranteed
reference to authenticated GitHub credentials.

Fortunately, when people are doing network access it _has_ to be on a
background thread. We can enforce that these background threads have
required the user to login, so at the point of executing the api
request, we will have credentials and can set them on the request.

Implementation-wise the important classes for this change are
AuthenticatedUserAsyncLoader & AuthenticatedUserAsyncTask, which enforce
that the user must be signed in before the rest of their background
threads run, LateAuthenticatedGitHubClient which only attempts to read
the GitHub credentials immediately before making it's API request
(which is implicitly on the background thread) and GitHubAccountScope,
a custom Guice scope used by the async loader/task classes to ensure
that the user is logged in and to make those GitHubAccount credentials
available for injection.

This commit also improves the background android-account sync in that
it now respects the account supplied to onPerformSync().
