### PR TITLE
fix #105: restore headlines of repository view

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/repo/RepositoryListFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/repo/RepositoryListFragment.java
@@ -58,6 +58,7 @@ public class RepositoryListFragment extends ItemListFragment<Repository>
         super.configureList(activity, listView);
 
         listView.setDividerHeight(0);
+        updateHeaders(items);
     }
 
     @Override


### PR DESCRIPTION
- Flipping to "Following" leads to the repository list being freed in
  the view pager.
- Flipping back, the headlines are not restored (only during initial
  repository loading).

This change restores the headers like done during the initial loading.
