### PR TITLE
refactoring: extract icon strings into separate resource

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -158,9 +158,6 @@
     <string name="anonymous">Anonymous</string>
     <string name="message_filter_saved">Issue filter saved to bookmarks</string>
     <string name="recent">Recent</string>
-    <string name="icon_pull_request">\uf20E</string>
-    <string name="icon_comment">\uf04f</string>
-    <string name="icon_file">\uf211</string>
     <string name="section_issue_status">Status:</string>
     <string name="status_open">Open</string>
     <string name="status_closed">Closed</string>
@@ -183,8 +180,6 @@
     <string name="members">Members</string>
     <string name="closing_issue">Closing Issue…</string>
     <string name="reopening_issue">Reopening Issue…</string>
-    <string name="icon_watch">\uf04E</string>
-    <string name="icon_fork">\uf020</string>
     <string name="avatar">Avatar</string>
     <string name="creating_issue">Creating Issue…</string>
     <string name="prefix_created">created\u0020</string>

--- a/app/res/values/typeface.xml
+++ b/app/res/values/typeface.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2012 GitHub Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<resources>
+    <string name="icon_pull_request">\uf20E</string>
+    <string name="icon_comment">\uf04f</string>
+    <string name="icon_file">\uf211</string>
+    <string name="icon_watch">\uf04E</string>
+    <string name="icon_fork">\uf020</string>
+    
+</resources>


### PR DESCRIPTION
- to avoid localization of icons from the github font
