### PR TITLE
Add SCM definition into pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <android.version>4.0.1.2</android.version>
     </properties>
+    <scm>
+        <connection>scm:git:git://github.com/github/android.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/github/android.git</developerConnection>
+        <url>https://github.com/github/android</url>
+    </scm>
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
May be useful for developers.
Also some CI servers may be autoconfigured with pom.xml, e.g. TeamCity.
