### PR TITLE
Spanish translation updated

### DIFF
--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -216,5 +216,11 @@
     <string name="parent_prefix">Anterior\u0020</string>
     <string name="authored">autor</string>
     <string name="committed">commit enviado</string>
+    <string name="diff_line_message">¿Qué deseas hacer?</string>
+    <string name="comment_on_line">Comentar linea</string>
+    <string name="view_entire_file">Ver fichero completo</string>
+    <string name="comparing_commits">Comparando {0} commits</string>
+    <string name="enable_wrapping">Habilitar ajuste de texto</string>
+    <string name="disable_wrapping">Deshabilitar ajuste de texto</string>
 
 </resources>


### PR DESCRIPTION
Hi there!
I've updated the Spanish translation but just to make sure it's ok I would like to ask a couple of thing before the merge:
- Is te comparing_commits message intended to work with number of commits (as in "Compare 3 commits") or with commits hashes (as in "Compare d8329:fc1cc commits")? The translation I made is for number of commits.
- Are the enable_wrapping and disable_wrapping messages about text wrapping? I assume the answer is yes, but I'm asking just in case.

Regards!
