### PR TITLE
Uncapitalize relative time span strings with prefix, fixes #165

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/StyledText.java
+++ b/app/src/main/java/com/github/mobile/ui/StyledText.java
@@ -140,7 +140,15 @@ public class StyledText extends SpannableStringBuilder {
      * @return this text
      */
     public StyledText append(final Date date) {
-        append(TimeUtils.getRelativeTime(date));
+        CharSequence timeString = TimeUtils.getRelativeTime(date);
+        // Un-capitalize time string if there is already a prefix.
+        // So you get "opened in 5 days" instead of "opened In 5 days".
+        if (this.length() > 0) {
+            append(timeString.subSequence(0, 1).toString().toLowerCase()).append(timeString.subSequence(1, timeString.length()));
+        }
+        else {
+            append(timeString);
+        }
         return this;
     }
 }


### PR DESCRIPTION
- issues are tagged like "opened Ago 5 days" in non English locales
- uncapitalize the time span string after non empty prefixes
