### PR TITLE
sync zh-rCN locale

### DIFF
--- a/app/res/values-zh-rCN/strings.xml
+++ b/app/res/values-zh-rCN/strings.xml
@@ -134,9 +134,6 @@
     <string name="milestone_prefix">里程碑:</string>
     <string name="edit_milestone">编辑里程碑</string>
     <string name="edit_assignee">编辑被指派人</string>
-    <string name="my_gists_tab">我的</string>
-    <string name="starred_gists_tab">已加星标</string>
-    <string name="all_gists_tab">所有</string>
     <string name="description">描述</string>
     <string name="gist_description_hint">从 Android 创建的 Gist</string>
     <string name="title">标题</string>
@@ -219,8 +216,8 @@
     <string name="commit_compare_title">提交比较</string>
     <string name="commit_prefix">提交\u0020</string>
     <string name="parent_prefix">先导\u0020</string>
-    <string name="authored">authored</string>
-    <string name="committed">committed</string>
+    <string name="authored">作于</string>
+    <string name="committed">提交于</string>
     <string name="diff_line_message">您想做什么？</string>
     <string name="comment_on_line">评论此行</string>
     <string name="view_entire_file">查看整个文件</string>
@@ -228,5 +225,26 @@
     <string name="enable_wrapping">启用自动折行</string>
     <string name="disable_wrapping">禁用自动折行</string>
     <string name="code">代码</string>
+
+    <!-- Tab titles, should be as short as possible -->
+    <string name="tab_repositories">版本库</string>
+    <string name="tab_news">新鲜事</string>
+    <string name="tab_following_self">我关注的</string>
+    <string name="tab_followers_self">关注我的</string>
+    <string name="tab_following">Ta关注的</string>
+    <string name="tab_followers">关注Ta的</string>
+    <string name="tab_members">成员</string>
+    <string name="tab_news">新鲜事</string>
+    <string name="tab_code">代码</string>
+    <string name="tab_commits">提交</string>
+    <string name="tab_issues">issues</string>
+    <string name="tab_watched">我关注的</string>
+    <string name="tab_assigned">指派给我的</string>
+    <string name="tab_created">我创建的</string>
+    <string name="tab_mentioned">提到我的</string>
+    <string name="tab_mine">我的</string>
+    <string name="tab_starred">已加星标</string>
+    <string name="tab_all">所有</string>
+    <!--  -->
 
 </resources>


### PR DESCRIPTION
This is zh-rCN locale updated to include all the tab titles, and a couple of messages that were forgotten some time ago.

BTW, are the new `tab_{watched,assigned,created,mentioned}` messages just a _rename_ of the now-unused `dashboard_{watched,assigned,created,mentioned}`? If that's the case (very likely), I'd probably open another PR to address this...
