### PR TITLE
list repositories in the overview starting with an number like 123test

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/repo/RepositoryListFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/repo/RepositoryListFragment.java
@@ -153,7 +153,7 @@ public class RepositoryListFragment extends ItemListFragment<Repository>
                 .getWrappedAdapter();
         adapter.clearHeaders();
 
-        char start = 'a';
+        char start = '-';
         Repository previous = null;
         for (int i = 0; i < repos.size(); i++) {
             Repository repository = repos.get(i);


### PR DESCRIPTION
As seen in Issue #282, repositories starting with an number are only shown in "recently viewed" and in the repository search. 

With this little change, those repositories are also shown in the repository overview. (i hope the change is as simple as this). 

![Screenshot](https://dl.dropbox.com/s/orskzkyih7mhn2t/Screenshot_2012-11-19-09-45-46.png?dl=1)
