### PR TITLE
[Bug] Markdown files render in commit view

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/commit/CommitFileViewActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/commit/CommitFileViewActivity.java
@@ -19,9 +19,14 @@ import static com.github.mobile.Intents.EXTRA_BASE;
 import static com.github.mobile.Intents.EXTRA_HEAD;
 import static com.github.mobile.Intents.EXTRA_PATH;
 import static com.github.mobile.Intents.EXTRA_REPOSITORY;
+import static com.github.mobile.util.PreferenceUtils.RENDER_MARKDOWN;
 import static com.github.mobile.util.PreferenceUtils.WRAP;
+
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v4.app.LoaderManager.LoaderCallbacks;
+import android.support.v4.content.Loader;
+import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
@@ -38,23 +43,48 @@ import com.github.mobile.R.string;
 import com.github.mobile.core.code.RefreshBlobTask;
 import com.github.mobile.core.commit.CommitUtils;
 import com.github.mobile.ui.BaseActivity;
+import com.github.mobile.ui.MarkdownLoader;
 import com.github.mobile.util.AvatarLoader;
+import com.github.mobile.util.HttpImageGetter;
 import com.github.mobile.util.PreferenceUtils;
 import com.github.mobile.util.ShareUtils;
 import com.github.mobile.util.SourceEditor;
 import com.github.mobile.util.ToastUtils;
 import com.google.inject.Inject;
 
+import java.io.Serializable;
+
 import org.eclipse.egit.github.core.Blob;
 import org.eclipse.egit.github.core.CommitFile;
+import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.Repository;
+import org.eclipse.egit.github.core.util.EncodingUtils;
 
 /**
  * Activity to display the contents of a file in a commit
  */
-public class CommitFileViewActivity extends BaseActivity {
+public class CommitFileViewActivity extends BaseActivity implements
+        LoaderCallbacks<CharSequence> {
 
     private static final String TAG = "CommitFileViewActivity";
+
+    private static final String ARG_TEXT = "text";
+
+    private static final String ARG_REPO = "repo";
+
+    private static final String[] MARKDOWN_EXTENSIONS = { ".md", ".mkdn",
+            ".mdwn", ".mdown", ".markdown", ".mkd", ".mkdown", ".ron" };
+
+    private static boolean isMarkdown(final String name) {
+        if (TextUtils.isEmpty(name))
+            return false;
+
+        for (String extension : MARKDOWN_EXTENSIONS)
+            if (name.endsWith(extension))
+                return true;
+
+        return false;
+    }
 
     /**
      * Create intent to show file in commit
@@ -82,14 +112,27 @@ public class CommitFileViewActivity extends BaseActivity {
 
     private String path;
 
+    private String file;
+
+    private boolean isMarkdownFile;
+
+    private String renderedMarkdown;
+
+    private Blob blob;
+
     private ProgressBar loadingBar;
 
     private WebView codeView;
 
     private SourceEditor editor;
 
+    private MenuItem markdownItem;
+
     @Inject
     private AvatarLoader avatars;
+
+    @Inject
+    private HttpImageGetter imageGetter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -104,6 +147,9 @@ public class CommitFileViewActivity extends BaseActivity {
 
         loadingBar = finder.find(id.pb_loading);
         codeView = finder.find(id.wv_code);
+
+        file = CommitUtils.getName(path);
+        isMarkdownFile = isMarkdown(file);
 
         editor = new SourceEditor(codeView);
         editor.setWrap(PreferenceUtils.getCodePreferences(this).getBoolean(
@@ -132,6 +178,17 @@ public class CommitFileViewActivity extends BaseActivity {
         else
             wrapItem.setTitle(string.enable_wrapping);
 
+        markdownItem = optionsMenu.findItem(id.m_render_markdown);
+        if (isMarkdownFile) {
+            markdownItem.setEnabled(blob != null);
+            markdownItem.setVisible(true);
+            if (PreferenceUtils.getCodePreferences(this).getBoolean(
+                    RENDER_MARKDOWN, true))
+                markdownItem.setTitle(string.show_raw_markdown);
+            else
+                markdownItem.setTitle(string.render_markdown);
+        }
+
         return true;
     }
 
@@ -139,22 +196,68 @@ public class CommitFileViewActivity extends BaseActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
         case id.m_wrap:
-            if (editor.getWrap()) {
+            if (editor.getWrap())
                 item.setTitle(string.enable_wrapping);
-                editor.setWrap(false);
-            } else {
+            else
                 item.setTitle(string.disable_wrapping);
-                editor.setWrap(true);
-            }
+            editor.toggleWrap();
             PreferenceUtils.save(PreferenceUtils.getCodePreferences(this)
                     .edit().putBoolean(WRAP, editor.getWrap()));
             return true;
+
         case id.m_share:
             shareFile();
             return true;
+
+        case id.m_render_markdown:
+            if (editor.isMarkdown()) {
+                item.setTitle(string.render_markdown);
+                editor.toggleMarkdown();
+                editor.setSource(file, blob);
+            } else {
+                item.setTitle(string.show_raw_markdown);
+                editor.toggleMarkdown();
+                if (renderedMarkdown != null)
+                    editor.setSource(file, renderedMarkdown, false);
+                else
+                    loadMarkdown();
+            }
+            PreferenceUtils.save(PreferenceUtils.getCodePreferences(this)
+                    .edit().putBoolean(RENDER_MARKDOWN, editor.isMarkdown()));
+            return true;
+
         default:
             return super.onOptionsItemSelected(item);
         }
+    }
+
+    @Override
+    public Loader<CharSequence> onCreateLoader(int loader, Bundle args) {
+        final String raw = args.getString(ARG_TEXT);
+        final IRepositoryIdProvider repo = (IRepositoryIdProvider) args
+                .getSerializable(ARG_REPO);
+        return new MarkdownLoader(this, repo, raw, imageGetter, false);
+    }
+
+    @Override
+    public void onLoadFinished(Loader<CharSequence> loader,
+            CharSequence rendered) {
+        if (rendered == null)
+            ToastUtils.show(this, string.error_rendering_markdown);
+
+        ViewUtils.setGone(loadingBar, true);
+        ViewUtils.setGone(codeView, false);
+
+        if (!TextUtils.isEmpty(rendered)) {
+            renderedMarkdown = rendered.toString();
+            if (markdownItem != null)
+                markdownItem.setEnabled(true);
+            editor.setMarkdown(true).setSource(file, renderedMarkdown, false);
+        }
+    }
+
+    @Override
+    public void onLoaderReset(Loader<CharSequence> loader) {
     }
 
     private void shareFile() {
@@ -162,6 +265,19 @@ public class CommitFileViewActivity extends BaseActivity {
         startActivity(ShareUtils.create(
                 path + " at " + CommitUtils.abbreviate(commit) + " on " + id,
                 "https://github.com/" + id + "/blob/" + commit + '/' + path));
+    }
+
+    private void loadMarkdown() {
+        ViewUtils.setGone(loadingBar, false);
+        ViewUtils.setGone(codeView, true);
+
+        String markdown = new String(
+                EncodingUtils.fromBase64(blob.getContent()));
+        Bundle args = new Bundle();
+        args.putCharSequence(ARG_TEXT, markdown);
+        if (repo instanceof Serializable)
+            args.putSerializable(ARG_REPO, (Serializable) repo);
+        getSupportLoaderManager().restartLoader(0, args, this);
     }
 
     private void loadContent() {
@@ -175,6 +291,21 @@ public class CommitFileViewActivity extends BaseActivity {
                 ViewUtils.setGone(codeView, false);
 
                 editor.setSource(path, blob);
+                CommitFileViewActivity.this.blob = blob;
+
+                if (markdownItem != null)
+                    markdownItem.setEnabled(true);
+
+                if (isMarkdownFile
+                        && PreferenceUtils.getCodePreferences(
+                                CommitFileViewActivity.this).getBoolean(
+                                RENDER_MARKDOWN, true))
+                    loadMarkdown();
+                else {
+                    ViewUtils.setGone(loadingBar, true);
+                    ViewUtils.setGone(codeView, false);
+                    editor.setSource(path, blob);
+                }
             }
 
             @Override
@@ -190,4 +321,5 @@ public class CommitFileViewActivity extends BaseActivity {
             }
         }.execute();
     }
+
 }

--- a/app/src/main/java/com/github/mobile/ui/ref/BranchFileViewActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/ref/BranchFileViewActivity.java
@@ -21,6 +21,7 @@ import static com.github.mobile.Intents.EXTRA_PATH;
 import static com.github.mobile.Intents.EXTRA_REPOSITORY;
 import static com.github.mobile.util.PreferenceUtils.RENDER_MARKDOWN;
 import static com.github.mobile.util.PreferenceUtils.WRAP;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.LoaderManager.LoaderCallbacks;
@@ -189,27 +190,27 @@ public class BranchFileViewActivity extends BaseActivity implements
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
         case id.m_wrap:
-            if (editor.getWrap()) {
+            if (editor.getWrap())
                 item.setTitle(string.enable_wrapping);
-                editor.setWrap(false);
-            } else {
+            else
                 item.setTitle(string.disable_wrapping);
-                editor.setWrap(true);
-            }
+            editor.toggleWrap();
             PreferenceUtils.save(PreferenceUtils.getCodePreferences(this)
                     .edit().putBoolean(WRAP, editor.getWrap()));
             return true;
+
         case id.m_share:
             shareFile();
             return true;
+
         case id.m_render_markdown:
             if (editor.isMarkdown()) {
                 item.setTitle(string.render_markdown);
-                editor.setMarkdown(false);
+                editor.toggleMarkdown();
                 editor.setSource(file, blob);
             } else {
                 item.setTitle(string.show_raw_markdown);
-                editor.setMarkdown(true);
+                editor.toggleMarkdown();
                 if (renderedMarkdown != null)
                     editor.setSource(file, renderedMarkdown, false);
                 else
@@ -218,6 +219,7 @@ public class BranchFileViewActivity extends BaseActivity implements
             PreferenceUtils.save(PreferenceUtils.getCodePreferences(this)
                     .edit().putBoolean(RENDER_MARKDOWN, editor.isMarkdown()));
             return true;
+
         default:
             return super.onOptionsItemSelected(item);
         }
@@ -281,10 +283,11 @@ public class BranchFileViewActivity extends BaseActivity implements
             protected void onSuccess(Blob blob) throws Exception {
                 super.onSuccess(blob);
 
+                BranchFileViewActivity.this.blob = blob;
+
                 if (markdownItem != null)
                     markdownItem.setEnabled(true);
 
-                BranchFileViewActivity.this.blob = blob;
                 if (isMarkdownFile
                         && PreferenceUtils.getCodePreferences(
                                 BranchFileViewActivity.this).getBoolean(

--- a/app/src/main/java/com/github/mobile/util/SourceEditor.java
+++ b/app/src/main/java/com/github/mobile/util/SourceEditor.java
@@ -198,4 +198,13 @@ public class SourceEditor {
     public SourceEditor toggleWrap() {
         return setWrap(!wrap);
     }
+
+    /**
+     * Toggle markdown file rendering
+     *
+     * @return this editor
+     */
+    public SourceEditor toggleMarkdown() {
+        return setMarkdown(!markdown);
+    }
 }


### PR DESCRIPTION
When a commit modifies a markdown file, in the commit list view, when you click on the markdown file, I would expect that the rendered version of the file is shown not the raw version. The same option to view either the rendered or raw version (like what is done when viewing a markdown file in the source tree) would be ideal.

Now when you click on the header for a markdown file in the commit
list view it acts the same way as if you were viewing the file in
the source tree view.
