### PR TITLE
Fix Repository News long press

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/repo/RepositoryNewsFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/repo/RepositoryNewsFragment.java
@@ -19,12 +19,15 @@ import static com.github.mobile.Intents.EXTRA_REPOSITORY;
 import android.app.Activity;
 
 import com.github.mobile.core.ResourcePager;
+import com.github.mobile.core.user.UserEventMatcher.UserPair;
 import com.github.mobile.ui.NewsFragment;
 import com.github.mobile.ui.issue.IssuesViewActivity;
 import com.github.mobile.ui.user.EventPager;
+import com.github.mobile.ui.user.UserViewActivity;
 
 import org.eclipse.egit.github.core.Issue;
 import org.eclipse.egit.github.core.Repository;
+import org.eclipse.egit.github.core.User;
 import org.eclipse.egit.github.core.client.PageIterator;
 import org.eclipse.egit.github.core.event.Event;
 
@@ -67,5 +70,17 @@ public class RepositoryNewsFragment extends NewsFragment {
     @Override
     protected void viewIssue(Issue issue, Repository repository) {
         startActivity(IssuesViewActivity.createIntent(issue, repo));
+    }
+
+    @Override
+    protected boolean viewUser(User user) {
+        startActivity(UserViewActivity.createIntent(user));
+        return true;
+    }
+
+    @Override
+    protected void viewUser(UserPair users) {
+        if (!viewUser(users.from))
+            viewUser(users.to);
     }
 }


### PR DESCRIPTION
Performing a long click on a repository news item and selecting one of
the choices did nothing because:
1) The current repository is already being shown
2) There was no viewUser function defined for RepositoryNewsFragment

This resolves the second issue.
