### PR TITLE
Added Gradle support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ gen-external-apklibs
 *.iml
 .DS_Store
 *.swp
+.gradle
+build


### PR DESCRIPTION
ADT 22.0+ and Android Studio uses Gradle as the build system.
