### PR TITLE
Show admin UI on issues only when appropriate.

### DIFF
--- a/app/res/layout/issue_edit.xml
+++ b/app/res/layout/issue_edit.xml
@@ -24,10 +24,19 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true" />
 
+    <ProgressBar
+        android:id="@+id/pb_loading"
+        style="@style/Spinner"
+        android:layout_centerInParent="true"
+        android:layout_width="64dp"
+        android:layout_height="64dp" />
+
     <ScrollView
+        android:id="@+id/sv_issue_content"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/v_header_separator" >
+        android:layout_below="@id/v_header_separator"
+        android:visibility="gone" >
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -44,10 +53,16 @@
                 style="@style/FormalSingleLineEditText"
                 android:layout_width="match_parent" />
 
+            <!-- We initially hide many of these because we don't know if the
+                the user is a collaborator, so we show them later as necessary
+            -->
+
             <TextView
+                android:id="@+id/tv_labels_label"
                 style="@style/HeaderTitleText"
                 android:paddingTop="5dp"
-                android:text="@string/labels" />
+                android:text="@string/labels"
+                android:visibility="gone" />
 
             <LinearLayout
                 android:id="@+id/ll_labels"
@@ -56,7 +71,8 @@
                 android:background="@drawable/inset_background"
                 android:gravity="center_vertical"
                 android:orientation="horizontal"
-                android:padding="10dp" >
+                android:padding="10dp"
+                android:visibility="gone" >
 
                 <TextView
                     android:id="@+id/tv_labels"
@@ -66,9 +82,11 @@
             </LinearLayout>
 
             <TextView
+                android:id="@+id/tv_assignee_label"
                 style="@style/HeaderTitleText"
                 android:paddingTop="5dp"
-                android:text="@string/assignee" />
+                android:text="@string/assignee"
+                android:visibility="gone" />
 
             <LinearLayout
                 android:id="@+id/ll_assignee"
@@ -77,7 +95,8 @@
                 android:background="@drawable/inset_background"
                 android:gravity="center_vertical"
                 android:orientation="horizontal"
-                android:padding="10dp" >
+                android:padding="10dp"
+                android:visibility="gone" >
 
                 <ImageView
                     android:id="@+id/iv_assignee_avatar"
@@ -93,9 +112,11 @@
             </LinearLayout>
 
             <TextView
+                android:id="@+id/tv_milestone_label"
                 style="@style/HeaderTitleText"
                 android:paddingTop="5dp"
-                android:text="@string/milestone" />
+                android:text="@string/milestone"
+                android:visibility="gone" />
 
             <LinearLayout
                 android:id="@+id/ll_milestone"
@@ -104,7 +125,8 @@
                 android:background="@drawable/inset_background"
                 android:gravity="center_vertical"
                 android:orientation="vertical"
-                android:padding="10dp" >
+                android:padding="10dp"
+                android:visibility="gone" >
 
                 <TextView
                     android:id="@+id/tv_milestone"


### PR DESCRIPTION
This is re: #413.  Before fields like labels and milestones were being shown to everyone when really they should only be shown to contributors.  For some reason the diff went kind of crazy despite me not making a huge number of changes.  If there's anything I can do to ease the review process definitely let me know.
