### PR TITLE
Fixed markdown rendering garbled characters

### DIFF
--- a/app/src/main/java/com/github/mobile/util/SourceEditor.java
+++ b/app/src/main/java/com/github/mobile/util/SourceEditor.java
@@ -168,8 +168,11 @@ public class SourceEditor {
 
     private void loadSource() {
         if (name != null && content != null)
+            // using loadDataWithBaseUrl is a work around to ensure that text
+            // is loaded using UTF-8 instead of ascii.  There is no baseUrl
             if (markdown)
-                view.loadData(content, "text/html", null);
+                view.loadDataWithBaseURL(null, content, "text/html", "UTF-8",
+                    null);
             else
                 view.loadUrl(URL_PAGE);
     }


### PR DESCRIPTION
Per #427, there was an issue where markdown files were having problems with multi-byte characters.  This should solve that problem.  See before and after screen shots.

![before](https://f.cloud.github.com/assets/1245354/1784052/b62f70d0-68cc-11e3-848b-0320fad0658c.png)

![after](https://f.cloud.github.com/assets/1245354/1784056/be40ab86-68cc-11e3-8fce-19ca66e36be2.png)
