### PR TITLE
Fix for soft keyboard appearing when viewing code

### DIFF
--- a/app/assets/lib/codemirror.js
+++ b/app/assets/lib/codemirror.js
@@ -17,7 +17,8 @@ window.CodeMirror = (function() {
         options[opt] = (givenOptions && givenOptions.hasOwnProperty(opt) ? givenOptions : defaults)[opt];
 
     var input = elt("textarea", null, null, "position: absolute; padding: 0; width: 1px; height: 1em");
-    input.setAttribute("wrap", "off"); input.setAttribute("autocorrect", "off"); input.setAttribute("autocapitalize", "off");
+    input.setAttribute("wrap", "off"); input.setAttribute("autocorrect", "off");
+    input.setAttribute("autocapitalize", "off"); input.setAttribute("readonly", "readonly");
     // Wraps and hides input textarea
     var inputDiv = elt("div", [input], null, "overflow: hidden; position: relative; width: 3px; height: 0px;");
     // The empty scrollbar content, used solely for managing the scrollbar thumb.


### PR DESCRIPTION
Previously, the soft keyboard would come up when the user tapped the
source code in a repo or gist, even though it isn’t editable. The built
in “readOnly” option in CodeMirror didn’t fix this.
