### PR TITLE
Fix for #495 Search Results doubled.

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/issue/SearchIssueListFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/SearchIssueListFragment.java
@@ -35,10 +35,8 @@ import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.egit.github.core.Issue;
 import org.eclipse.egit.github.core.Repository;


### PR DESCRIPTION
I don't know if the search issue service is being changed but it was returning in both calls for open and closed issues the same issues, I would like to use a Set in this approach but I could not modify the SearchIssue object in order to modify equals method so I used the filter with a HashMap/SparseArray approach.

I could not find unit tests, let me know if unit test is needed for the filterSearch method and I will provide it asap.

Cheers.
