### PR TITLE
Tightened regex on UserUrlMatcher. Closes #554.

### DIFF
--- a/app/src/main/java/com/github/mobile/core/user/UserUrlMatcher.java
+++ b/app/src/main/java/com/github/mobile/core/user/UserUrlMatcher.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
  */
 public class UserUrlMatcher extends UrlMatcher {
 
-    private static final String REGEX = "^https?://[^/]+/([^/]+)$";
+    private static final String REGEX = "^https?://(www\\.)?github.com/([^/]+)$";
 
     private static final Pattern PATTERN = Pattern.compile(REGEX);
 


### PR DESCRIPTION
The regex matched pastebin urls, resulting in the app trying to open them as GitHub users. This fixes that.
