### PR TITLE
fixes #591, html encoding missing

### DIFF
--- a/app/src/main/java/com/github/mobile/util/SourceEditor.java
+++ b/app/src/main/java/com/github/mobile/util/SourceEditor.java
@@ -169,7 +169,7 @@ public class SourceEditor {
     private void loadSource() {
         if (name != null && content != null)
             if (markdown)
-                view.loadData(content, "text/html", null);
+                view.loadData(content, "text/html; charset=utf-8", null);
             else
                 view.loadUrl(URL_PAGE);
     }


### PR DESCRIPTION
The problem was a typical encoding mismatch, with the web view defaulting to ISO-8859-1.
