### PR TITLE
Fix #508 #427

### DIFF
--- a/app/src/main/java/com/github/mobile/util/SourceEditor.java
+++ b/app/src/main/java/com/github/mobile/util/SourceEditor.java
@@ -169,7 +169,7 @@ public class SourceEditor {
     private void loadSource() {
         if (name != null && content != null)
             if (markdown)
-                view.loadData(content, "text/html; charset=utf-8", null);
+                view.loadDataWithBaseURL(null, content, "text/html", CHARSET_UTF8, null);
             else
                 view.loadUrl(URL_PAGE);
     }


### PR DESCRIPTION
[loadData](http://developer.android.com/reference/android/webkit/WebView.html#loadData%28java.lang.String, java.lang.String, java.lang.String%29)

> The encoding parameter specifies whether the data is base64 or URL encoded. If the data is base64 encoded, the value of the encoding parameter must be 'base64'. For all other values of the parameter, including null, it is assumed that the data uses ASCII encoding for octets inside the range of safe URL characters and use the standard %xx hex encoding of URLs for octets outside that range. For example, '#', '%', '\', '?' should be replaced by %23, %25, %27, %3f respectively.

Cause markdown garbled.
- before
  ![Fix ago](http://api.drp.io/files/546bc22109260.png)
- after
  ![Fix after](http://api.drp.io/files/546bc220f0515.png)
