### PR TITLE
Improve the SwipeRefreshLayout and remove the old loading indicator

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/DialogFragmentActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/DialogFragmentActivity.java
@@ -36,8 +36,6 @@ public abstract class DialogFragmentActivity extends
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        requestWindowFeature(FEATURE_INDETERMINATE_PROGRESS);
-
         super.onCreate(savedInstanceState);
 
         finder = new ViewFinder(this);

--- a/app/src/main/java/com/github/mobile/ui/ItemListFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/ItemListFragment.java
@@ -34,6 +34,7 @@ import android.widget.Toast;
 
 import com.github.kevinsawicki.wishlist.SingleTypeAdapter;
 import com.github.kevinsawicki.wishlist.ViewUtils;
+import com.github.mobile.R.color;
 import com.github.mobile.R.id;
 import com.github.mobile.R.layout;
 import com.github.mobile.ThrowableLoader;
@@ -42,7 +43,6 @@ import java.util.Collections;
 import java.util.List;
 
 import android.support.v4.widget.SwipeRefreshLayout;
-import static android.R.color;
 
 /**
  * Base fragment for displaying a list of items that loads with a progress bar
@@ -53,8 +53,9 @@ import static android.R.color;
 public abstract class ItemListFragment<E> extends DialogFragment implements
         LoaderCallbacks<List<E>>, SwipeRefreshLayout.OnRefreshListener {
 
-    SwipeRefreshLayout swipeLayout;
     private static final String FORCE_REFRESH = "forceRefresh";
+
+    private SwipeRefreshLayout swipeLayout;
 
     /**
      * @param args
@@ -110,8 +111,8 @@ public abstract class ItemListFragment<E> extends DialogFragment implements
     @Override
     public void onRefresh() {
         forceRefresh();
-        swipeLayout.setRefreshing(false);
     }
+
     /**
      * Detach from list view.
      */
@@ -132,10 +133,10 @@ public abstract class ItemListFragment<E> extends DialogFragment implements
         swipeLayout = (SwipeRefreshLayout) view.findViewById(id.swipe_item);
         swipeLayout.setOnRefreshListener(this);
         swipeLayout.setColorSchemeResources(
-            color.holo_blue_bright,
-            color.holo_green_light,
-            color.holo_orange_light,
-            color.holo_red_light);
+            color.pager_title_background_top_start,
+            color.pager_title_background_end,
+            color.text_link,
+            color.pager_title_background_end);
 
         listView = (ListView) view.findViewById(android.R.id.list);
         listView.setOnItemClickListener(new OnItemClickListener() {
@@ -192,8 +193,6 @@ public abstract class ItemListFragment<E> extends DialogFragment implements
         if (!isUsable())
             return;
 
-        getSherlockActivity()
-                .setSupportProgressBarIndeterminateVisibility(true);
         getLoaderManager().restartLoader(0, args, this);
     }
 
@@ -209,8 +208,7 @@ public abstract class ItemListFragment<E> extends DialogFragment implements
         if (!isUsable())
             return;
 
-        getSherlockActivity().setSupportProgressBarIndeterminateVisibility(
-                false);
+        swipeLayout.setRefreshing(false);
         Exception exception = getException(loader);
         if (exception != null) {
             showError(exception, getErrorMessage(exception));

--- a/app/src/main/java/com/github/mobile/ui/commit/CommitDiffListFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/commit/CommitDiffListFragment.java
@@ -244,9 +244,6 @@ public class CommitDiffListFragment extends DialogFragment implements
     }
 
     private void refreshCommit() {
-        getSherlockActivity()
-                .setSupportProgressBarIndeterminateVisibility(true);
-
         new RefreshCommitTask(getActivity(), repository, base,
                 commentImageGetter) {
 
@@ -264,21 +261,14 @@ public class CommitDiffListFragment extends DialogFragment implements
             @Override
             protected void onSuccess(FullCommit commit) throws Exception {
                 super.onSuccess(commit);
-
                 updateList(commit.getCommit(), commit, commit.getFiles());
-                getSherlockActivity()
-                        .setSupportProgressBarIndeterminateVisibility(false);
             }
 
             @Override
             protected void onException(Exception e) throws RuntimeException {
                 super.onException(e);
-
                 ToastUtils.show(getActivity(), e, string.error_commit_load);
                 ViewUtils.setGone(progress, true);
-
-                getSherlockActivity()
-                        .setSupportProgressBarIndeterminateVisibility(false);
             }
 
         }.execute();

--- a/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
@@ -407,15 +407,11 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
     }
 
     private void refreshGist() {
-        getSherlockActivity().setSupportProgressBarIndeterminateVisibility(true);
-
         new RefreshGistTask(getActivity(), gistId, imageGetter) {
 
             @Override
             protected void onException(Exception e) throws RuntimeException {
                 super.onException(e);
-
-                getSherlockActivity().setSupportProgressBarIndeterminateVisibility(false);
                 ToastUtils.show(getActivity(), e, string.error_gist_load);
             }
 
@@ -437,8 +433,6 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                 gist = fullGist.getGist();
                 comments = fullGist;
                 updateList(fullGist.getGist(), fullGist);
-
-                getSherlockActivity().setSupportProgressBarIndeterminateVisibility(false);
             }
 
         }.execute();

--- a/app/src/main/java/com/github/mobile/ui/issue/IssueFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/IssueFragment.java
@@ -444,19 +444,14 @@ public class IssueFragment extends DialogFragment {
     }
 
     private void refreshIssue() {
-        getSherlockActivity().setSupportProgressBarIndeterminateVisibility(true);
-
         new RefreshIssueTask(getActivity(), repositoryId, issueNumber,
                 bodyImageGetter, commentImageGetter) {
 
             @Override
             protected void onException(Exception e) throws RuntimeException {
                 super.onException(e);
-
                 ToastUtils.show(getActivity(), e, string.error_issue_load);
                 ViewUtils.setGone(progress, true);
-
-                getSherlockActivity().setSupportProgressBarIndeterminateVisibility(false);
             }
 
             @Override
@@ -469,8 +464,6 @@ public class IssueFragment extends DialogFragment {
                 issue = fullIssue.getIssue();
                 comments = fullIssue;
                 updateList(fullIssue.getIssue(), fullIssue);
-
-                getSherlockActivity().setSupportProgressBarIndeterminateVisibility(false);
             }
         }.execute();
 


### PR DESCRIPTION
Remove the loading indicator from the action bar as it's not needed anymore and it shouldn't be used in the new Android guidelines. I made the SwipeRefreshLayout stay visible until the loading has finished so we have a loading indicator.

I also changed the SwipeRefreshLayout's colors as Holo isn't supported prior to API 14 and we support up to API 8.
