### PR TITLE
Don't accept 'orgs' as a valid user name

### DIFF
--- a/app/src/main/java/com/github/mobile/core/repo/RepositoryUtils.java
+++ b/app/src/main/java/com/github/mobile/core/repo/RepositoryUtils.java
@@ -71,6 +71,7 @@ public class RepositoryUtils {
                 || "new".equals(name) //
                 || "notifications".equals(name) //
                 || "organizations".equals(name) //
+                || "orgs".equals(name) //
                 || "repositories".equals(name) //
                 || "search".equals(name) //
                 || "security".equals(name) //


### PR DESCRIPTION
The URL http://github.com/orgs/github/ shouldn't be treated as repo github of the user orgs
