### PR TITLE
[Fix #810] Remove unnecessary issue events

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -289,6 +289,10 @@
     <string name="copy_hash">Copy hash</string>
     <string name="toast_msg_copied">Copied to clipboard</string>
 
+    <!-- issue events -->
+    <string name="event_mentioned" translatable="false">mentioned</string>
+    <string name="event_subscribed" translatable="false">subscribed</string>
+
     <!-- Navigation drawer strings -->
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>

--- a/app/src/main/java/com/github/mobile/ui/issue/IssueFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/IssueFragment.java
@@ -15,33 +15,10 @@
  */
 package com.github.mobile.ui.issue;
 
-import static android.app.Activity.RESULT_OK;
-import static android.view.View.GONE;
-import static android.view.View.VISIBLE;
-import static com.github.mobile.Intents.EXTRA_COMMENT;
-import static com.github.mobile.Intents.EXTRA_ISSUE;
-import static com.github.mobile.Intents.EXTRA_ISSUE_NUMBER;
-import static com.github.mobile.Intents.EXTRA_IS_COLLABORATOR;
-import static com.github.mobile.Intents.EXTRA_IS_OWNER;
-import static com.github.mobile.Intents.EXTRA_REPOSITORY_NAME;
-import static com.github.mobile.Intents.EXTRA_REPOSITORY_OWNER;
-import static com.github.mobile.Intents.EXTRA_USER;
-import static com.github.mobile.RequestCodes.COMMENT_CREATE;
-import static com.github.mobile.RequestCodes.COMMENT_DELETE;
-import static com.github.mobile.RequestCodes.COMMENT_EDIT;
-import static com.github.mobile.RequestCodes.ISSUE_ASSIGNEE_UPDATE;
-import static com.github.mobile.RequestCodes.ISSUE_CLOSE;
-import static com.github.mobile.RequestCodes.ISSUE_EDIT;
-import static com.github.mobile.RequestCodes.ISSUE_LABELS_UPDATE;
-import static com.github.mobile.RequestCodes.ISSUE_MILESTONE_UPDATE;
-import static com.github.mobile.RequestCodes.ISSUE_REOPEN;
-import static com.github.mobile.util.TypefaceUtils.ICON_COMMIT;
-import static org.eclipse.egit.github.core.service.IssueService.STATE_OPEN;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -79,13 +56,6 @@ import com.github.mobile.util.ToastUtils;
 import com.github.mobile.util.TypefaceUtils;
 import com.google.inject.Inject;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-
 import org.eclipse.egit.github.core.Comment;
 import org.eclipse.egit.github.core.Issue;
 import org.eclipse.egit.github.core.IssueEvent;
@@ -95,6 +65,36 @@ import org.eclipse.egit.github.core.PullRequest;
 import org.eclipse.egit.github.core.Repository;
 import org.eclipse.egit.github.core.RepositoryId;
 import org.eclipse.egit.github.core.User;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+import static android.app.Activity.RESULT_OK;
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+import static com.github.mobile.Intents.EXTRA_COMMENT;
+import static com.github.mobile.Intents.EXTRA_ISSUE;
+import static com.github.mobile.Intents.EXTRA_ISSUE_NUMBER;
+import static com.github.mobile.Intents.EXTRA_IS_COLLABORATOR;
+import static com.github.mobile.Intents.EXTRA_IS_OWNER;
+import static com.github.mobile.Intents.EXTRA_REPOSITORY_NAME;
+import static com.github.mobile.Intents.EXTRA_REPOSITORY_OWNER;
+import static com.github.mobile.Intents.EXTRA_USER;
+import static com.github.mobile.RequestCodes.COMMENT_CREATE;
+import static com.github.mobile.RequestCodes.COMMENT_DELETE;
+import static com.github.mobile.RequestCodes.COMMENT_EDIT;
+import static com.github.mobile.RequestCodes.ISSUE_ASSIGNEE_UPDATE;
+import static com.github.mobile.RequestCodes.ISSUE_CLOSE;
+import static com.github.mobile.RequestCodes.ISSUE_EDIT;
+import static com.github.mobile.RequestCodes.ISSUE_LABELS_UPDATE;
+import static com.github.mobile.RequestCodes.ISSUE_MILESTONE_UPDATE;
+import static com.github.mobile.RequestCodes.ISSUE_REOPEN;
+import static com.github.mobile.util.TypefaceUtils.ICON_COMMIT;
+import static org.eclipse.egit.github.core.service.IssueService.STATE_OPEN;
 
 /**
  * Fragment to display an issue
@@ -476,7 +476,10 @@ public class IssueFragment extends DialogFragment {
                     for (int e = start; e < numEvents; e++) {
                         IssueEvent event = events.get(e);
                         if (comment.getCreatedAt().after(event.getCreatedAt())) {
-                            allItems.add(event);
+                            if (!(event.getEvent().equalsIgnoreCase(getString(R.string.event_mentioned)) ||
+                                    event.getEvent().equalsIgnoreCase(getString(R.string.event_subscribed)))) {
+                                allItems.add(event);
+                            }
                             start++;
                         } else {
                             e = events.size();
@@ -486,9 +489,12 @@ public class IssueFragment extends DialogFragment {
                 }
 
                 // Adding the last events or if there are no comments
-                for(int e = start; e < events.size(); e++) {
+                for (int e = start; e < events.size(); e++) {
                     IssueEvent event = events.get(e);
-                    allItems.add(event);
+                    if (!(event.getEvent().equalsIgnoreCase(getString(R.string.event_mentioned)) ||
+                            event.getEvent().equalsIgnoreCase(getString(R.string.event_subscribed)))) {
+                        allItems.add(event);
+                    }
                 }
 
                 items = allItems;


### PR DESCRIPTION
"subscribed" and "mentioned" events only add meaningless
values during viewing issue details.
Oftenly, these will fill spaces between comments, making it
unclear to get the comment flow. More even so, when many people
are involved.
