### PR TITLE
 "log out" feature in the navigation drawer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -229,7 +229,8 @@
         <activity
             android:name=".accounts.LoginActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:excludeFromRecents="true">
+            android:excludeFromRecents="true"
+            android:noHistory="true">
 
             <!--
                 No intent-filter here! This activity is only ever launched by

--- a/app/src/main/java/com/github/mobile/ui/MainActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/MainActivity.java
@@ -3,10 +3,13 @@ package com.github.mobile.ui;
 import static com.github.mobile.ui.NavigationDrawerObject.TYPE_SEPERATOR;
 import android.app.SearchManager;
 import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.LoaderManager;
+import android.support.v4.content.IntentCompat;
 import android.support.v4.content.Loader;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.widget.DrawerLayout;
@@ -18,6 +21,7 @@ import android.view.Window;
 
 import com.github.mobile.R;
 import com.github.mobile.accounts.AccountUtils;
+import com.github.mobile.accounts.LoginActivity;
 import com.github.mobile.core.user.UserComparator;
 import com.github.mobile.persistence.AccountDataManager;
 import com.github.mobile.ui.gist.GistsPagerFragment;
@@ -38,6 +42,8 @@ public class MainActivity extends BaseActivity implements NavigationDrawerFragme
     LoaderManager.LoaderCallbacks<List<User>> {
 
     private static final String TAG = "MainActivity";
+    public static final String STRING_LOGGED_IN = "log";
+    public static boolean RESULT_LOG_IN = false;
 
     private NavigationDrawerFragment mNavigationDrawerFragment;
 
@@ -53,6 +59,8 @@ public class MainActivity extends BaseActivity implements NavigationDrawerFragme
 
     private User org;
 
+    private SharedPreferences sp;
+
     @Inject
     private AvatarLoader avatars;
 
@@ -60,6 +68,14 @@ public class MainActivity extends BaseActivity implements NavigationDrawerFragme
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        sp = getSharedPreferences(STRING_LOGGED_IN,0);
+        boolean result = sp.getBoolean(STRING_LOGGED_IN, false);
+        if (result) {
+            Intent in = new Intent(this, LoginActivity.class);
+            startActivity(in);
+        }
+
         setSupportActionBar((android.support.v7.widget.Toolbar) findViewById(R.id.toolbar));
 
         getSupportLoaderManager().initLoader(0, null, this);
@@ -161,6 +177,17 @@ public class MainActivity extends BaseActivity implements NavigationDrawerFragme
             case 4:
                 fragment = new FilterListFragment();
                 break;
+            case 5:
+                RESULT_LOG_IN = true;
+                SharedPreferences.Editor editor = sp.edit();
+                editor.putBoolean(STRING_LOGGED_IN, RESULT_LOG_IN);
+                editor.commit();
+                Intent in = new Intent(this, LoginActivity.class);
+                in.addFlags(IntentCompat.FLAG_ACTIVITY_CLEAR_TASK
+                        | Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(in);
+                finish();
+                return;
             default:
                 fragment = new HomePagerFragment();
                 args.putSerializable("org", orgs.get(position - 6));

--- a/app/src/main/java/com/github/mobile/ui/NavigationDrawerAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/NavigationDrawerAdapter.java
@@ -40,7 +40,7 @@ public class NavigationDrawerAdapter extends BaseAdapter {
     private void createData() {
         orgs.remove(0);
         String[] names = new String[] { context.getString(R.string.home), context.getString(R.string.gist),
-            context.getString(R.string.issue_dashboard), context.getString(R.string.bookmarks) };
+            context.getString(R.string.issue_dashboard), context.getString(R.string.bookmarks), context.getString(R.string.log_out)};
         String[] icons = context.getResources().getStringArray(R.array.navigation_drawer_icon_list);
         data = new ArrayList<>();
         int amount = names.length + orgs.size() + 2;

--- a/app/src/main/java/com/github/mobile/ui/NavigationDrawerObject.java
+++ b/app/src/main/java/com/github/mobile/ui/NavigationDrawerObject.java
@@ -7,6 +7,7 @@ public class NavigationDrawerObject {
     public static final int TYPE_SUBHEADER = 0;
     public static final int TYPE_ITEM_MENU = 1;
     public static final int TYPE_ITEM_ORG = 2;
+    public static final int TYPE_LOG_OUT = 3;
 
     private String title;
     private String iconString;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
 
     <string name="app_name">GitHub</string>
     <string name="home">Home</string>
+    <string name="log_out">Log Out</string>
     <string name="news">News</string>
     <string name="issues">Issues</string>
     <string name="gists">Gists</string>

--- a/app/src/main/res/values/typeface.xml
+++ b/app/src/main/res/values/typeface.xml
@@ -30,5 +30,6 @@
         <item>\uf00e</item>
         <item>\uf07d</item>
         <item>\uf07b</item>
+        <item>\uf07e</item>
     </string-array>
 </resources>


### PR DESCRIPTION
I added a log out feature in the navigation drawer to make it easy for users to access. Through shared preferences I save and  keep track of  the user's activity state (either logged in or out) to make sure that the log out process gets validated when the user leaves the app and launches it again later.