### PR TITLE
Use travis' container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ jdk: oraclejdk7
 notifications:
   email: false
 
-before_install:
-  - sudo apt-get update -qq
-  - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch > /dev/null; fi
+sudo: false
 
 script:
   - ./gradlew clean build


### PR DESCRIPTION
Since we don't need sudo, travis can run builds on it's container based infrastructure

More information:
http://docs.travis-ci.com/user/migrating-from-legacy/