### PR TITLE
Add progress dialog during webpage loading

### DIFF
--- a/app/src/main/java/com/github/pockethub/accounts/LoginWebViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/accounts/LoginWebViewActivity.java
@@ -1,12 +1,14 @@
 package com.github.pockethub.accounts;
 
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.webkit.WebViewClient;
 
 import com.github.pockethub.R;
+import com.github.pockethub.ui.LightProgressDialog;
 import com.github.pockethub.ui.WebView;
 
 public class LoginWebViewActivity extends AppCompatActivity {
@@ -17,6 +19,19 @@ public class LoginWebViewActivity extends AppCompatActivity {
         WebView webView = new WebView(this);
         webView.loadUrl(getIntent().getStringExtra(LoginActivity.INTENT_EXTRA_URL));
         webView.setWebViewClient(new WebViewClient() {
+            LightProgressDialog dialog = (LightProgressDialog) LightProgressDialog.create(
+                    LoginWebViewActivity.this, R.string.loading);
+
+            @Override
+            public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
+                dialog.show();
+            }
+
+            @Override
+            public void onPageFinished(android.webkit.WebView view, String url) {
+                dialog.dismiss();
+            }
+
             @Override
             public boolean shouldOverrideUrlLoading(android.webkit.WebView view, String url) {
                 Uri uri = Uri.parse(url);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
     <string name="loading_commits">Loading Commits…</string>
     <string name="loading_files_and_comments">Loading Files &amp; Comments…</string>
     <string name="loading_refs">Loading Branches &amp; Tags…</string>
+    <string name="loading">Loading…</string>
     <!--  -->
 
 


### PR DESCRIPTION
After "log in" is pressed, there's a blank
white screen for several seconds.
This will be an indicator that something
is happening (which is loading the webpage).
It's better  than leaving the user wondering.

![screen shot 2015-08-22 at 9 55 42 am](https://cloud.githubusercontent.com/assets/6204776/9422219/95b8694a-48b5-11e5-94d8-59ca661408a6.png)
