### PR TITLE
Set github oauth values via simple gradle properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,5 @@ notifications:
 
 sudo: false
 
-before_script:
-  -  openssl aes-256-cbc -K $encrypted_7e1c958561a2_key -iv $encrypted_7e1c958561a2_iv -in github.properties.enc -out github.properties -d
 script:
   - ./gradlew clean build

--- a/README.md
+++ b/README.md
@@ -41,14 +41,11 @@ are welcomed and appreciated but will be thoroughly reviewed and discussed. **Pl
 ## Setup Environment
 
 1. Create a github application (https://github.com/settings/applications/new)
-2. Create a github.properties in the root folder of the repo
-3. Add these three values to the github.properties
+2. Set the following gradle properties via one of the ways described [here](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_properties_and_system_properties):
+  - ```pockethub_github_client```=your_application_client_id
+  - ```pockethub_github_secret```=your_application_client_secret
+  - ```pockethub_github_callback```=your_callback_url
 
-```
-GITHUB_CLIENT=your_application_client_id
-GITHUB_SECRET=your_application_client_secret
-GITHUB_CALLBACK=your_callback_url
-```
 (The callback url needs to be in the format "your_schema://whatever_you_want")
 
 ## Legacy Notes

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,17 +29,10 @@ android {
         versionCode versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100 + versionBuild
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
 
-        def Properties githubProps = new Properties()
-        if (file('../github.properties').exists()) {
-            githubProps.load(new FileInputStream(file('../github.properties')))
-        } else {
-            logger.log(LogLevel.ERROR, "github.properties can not be found, please add it to the project root")
-        }
-            
-        resValue "string", "github_secret", getValue(githubProps, "GITHUB_SECRET")
-        resValue "string", "github_client", getValue(githubProps, "GITHUB_CLIENT")
+        resValue "string", "github_secret", pockethub_github_secret
+        resValue "string", "github_client", pockethub_github_client
 
-        String oauth = getValue(githubProps, "GITHUB_CALLBACK")
+        String oauth = pockethub_github_callback
         resValue "string", "github_oauth", oauth
         resValue "string", "github_oauth_scheme", oauth != "DEFAULT" ? oauth.split("://")[0] : "DEFAULT"
 
@@ -64,17 +57,6 @@ android {
 
         // False for now until we set up Travis CI for this
         preDexLibraries = false
-    }
-}
-
-def String getValue(Properties props, String name) {
-    if (props && props[name]) {
-        return props[name]
-    } else if (System.getenv(name)) {
-        return System.getenv(name)
-    } else {
-        logger.log(LogLevel.ERROR, name + " has not been provided, add it to your github.properties file")
-        return "DEFAULT"
     }
 }
 

--- a/github.properties.enc
+++ b/github.properties.enc
@@ -1,1 +1,0 @@
-­L€õ_;­ÄôV»8×\"#=ÊiÛ­ÿÎ 2J¶;Þ¬­þc‰_&lÔ»‰,¢ÉW¥/¹¶¿n–b22–—ÛL¨Éwåhìüsðo!öIªUÏ(U¸ÏÅ³äP˜4\hkèa°Ïq÷1¶–yü§!/fAD[UGJ1=-ªefé„®Àäb$ÀKaÔt

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,7 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+pockethub_github_client=dummy
+pockethub_github_secret=dummy
+pockethub_github_callback=http://dummy.example.com


### PR DESCRIPTION
Let's use simple gradle properties as described here (https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_properties_and_system_properties) in order to set the github specific oauth values

fixes #884