### PR TITLE
Fixed IndexOutOfBoundsException after clicking the last Organization in the drawer

### DIFF
--- a/app/src/main/java/com/github/pockethub/ui/MainActivity.java
+++ b/app/src/main/java/com/github/pockethub/ui/MainActivity.java
@@ -204,7 +204,7 @@ public class MainActivity extends BaseActivity implements NavigationDrawerFragme
                 return;
             default:
                 fragment = new HomePagerFragment();
-                args.putParcelable("org", orgs.get(position - 6));
+                args.putParcelable("org", orgs.get(position - 7));
                 break;
         }
         fragment.setArguments(args);


### PR DESCRIPTION
I noticed that after the logout item was added to the drawer, clicking on the last organization you have will crash the application with an java.lang.IndexOutOfBoundsException. Also, if you have multiple organizations, clicking on one will cause it to show the organization below instead. This small fix will ensure that clicking on an organization selects the organization correctly.