### PR TITLE
use only one http-client library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,6 @@ dependencies {
     compile 'com.squareup.picasso:picasso:2.5.0'
     compile 'com.squareup.okhttp:okhttp:2.4.0'
     compile 'org.roboguice:roboguice:2.0'
-    compile 'com.github.kevinsawicki:http-request:5.6'
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'org.eclipse.mylyn.github:org.eclipse.egit.github.core:3.7.0.201502260915-r'
     compile ('com.google.inject.extensions:guice-assistedinject:3.0'){


### PR DESCRIPTION
Let's use okhttp for all http requests so we don't need multiple http client libraries

retrofit and picasso are also using okhttp