### PR TITLE
bug-fix: Issue 892 - News Crash

### DIFF
--- a/app/src/main/java/com/github/pockethub/util/ConvertUtils.java
+++ b/app/src/main/java/com/github/pockethub/util/ConvertUtils.java
@@ -4,11 +4,19 @@ import com.alorma.github.sdk.bean.dto.response.Repo;
 import com.alorma.github.sdk.bean.dto.response.User;
 
 public class ConvertUtils {
-    public static Repo eventRepoToRepo(Repo repo) {
-        String[] ref = repo.name.split("/");
-        repo.owner = new User();
-        repo.owner.login = ref[0];
-        repo.name = ref[1];
-        return repo;
-    }
+
+	/**
+	 * Converts an event repo to a new, clean repo.
+	 *
+	 * @param repo The original repo.
+	 * @return A new repo, with a name and a new owner's login.
+	 */
+	public static Repo eventRepoToRepo(Repo repo) {
+		Repo newRepo = new Repo();
+		String[] ref = repo.name.split("/");
+		newRepo.owner = new User();
+		newRepo.owner.login = ref[0];
+		newRepo.name = ref[1];
+		return newRepo;
+	}
 }

--- a/app/src/test/java/com/github/pockethub/util/ConvertUtilsTest.java
+++ b/app/src/test/java/com/github/pockethub/util/ConvertUtilsTest.java
@@ -1,0 +1,43 @@
+package com.github.pockethub.util;
+
+import com.alorma.github.sdk.bean.dto.response.Repo;
+import com.alorma.github.sdk.bean.dto.response.User;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ConvertUtilsTest {
+
+	private static final String REPO_NAME_FIRST_PART = "first";
+	private static final String REPO_NAME_SECOND_PART = "second";
+	private static final String REPO_NAME = REPO_NAME_FIRST_PART + "/" + REPO_NAME_SECOND_PART;
+	private static final String REPO_OWNER_LOGIN = "repo_owner_login";
+
+	private Repo repo;
+
+	@Before
+	public void setup() {
+		repo = new Repo();
+		repo.name = REPO_NAME;
+		repo.owner = new User();
+		repo.owner.login = REPO_OWNER_LOGIN;
+	}
+
+	@Test
+	public void testOriginalRepoIsNotChanged() throws Exception {
+		ConvertUtils.eventRepoToRepo(repo);
+		assertThat(repo.owner.login, equalTo(REPO_OWNER_LOGIN));
+		assertThat(repo.name, equalTo(REPO_NAME));
+	}
+
+	@Test
+	public void testNewRepoIsCreated() throws Exception {
+		Repo newRepo = ConvertUtils.eventRepoToRepo(repo);
+		assertThat(newRepo.owner.login, equalTo(REPO_NAME_FIRST_PART));
+		assertThat(newRepo.name, equalTo(REPO_NAME_SECOND_PART));
+	}
+
+}


### PR DESCRIPTION
Fix for https://github.com/pockethub/PocketHub/issues/892.

Current behaviour: Long pressing a news item, dismissing the dialog and long pressing again would crash the app.
![news_navigate_dialog_crash](https://cloud.githubusercontent.com/assets/1117022/10416580/491cc85c-7014-11e5-8a4e-f33cb3291e2e.gif)

This was due to the utility method that converts a *news repo* to a new repo changing the original *news repo*.

Fixed behaviour:
![news_navigate_dialog_fix](https://cloud.githubusercontent.com/assets/1117022/10416596/824a7340-7014-11e5-91bc-ec926683ad8d.gif)
