### PR TITLE
adjust icon alignment on api 23

### DIFF
--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="ListIcon" parent="TextIcon">
+        <item name="android:textSize">14sp</item>
+        <item name="android:layout_marginTop">0dp</item>
+        <item name="android:maxHeight">18dp</item>
+    </style>
+
+    <style name="EventIcon" parent="TextIcon">
+        <item name="android:textSize">22sp</item>
+        <item name="android:layout_marginTop">0dp</item>
+        <item name="android:maxHeight">28dp</item>
+    </style>
+
+    <style name="PrimaryIcon" parent="TextIcon">
+        <item name="android:layout_marginTop">0dp</item>
+        <item name="android:textSize">28sp</item>
+        <item name="android:maxHeight">35dp</item>
+    </style>
+</resources>


### PR DESCRIPTION
fixes #929 

I've copied the icon-styles to `values-v23`, set `android:layout_marginTop` to `0dp` and replaced `android:layout_height` with `android:maxHeight`