### PR TITLE
Use the android:label attribute in favor of ActionBar.setTitle()

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
         <activity
             android:name="com.github.pockethub.ui.gist.CreateGistActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:label="@string/create_gist">
+            android:label="@string/new_gist">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -70,7 +70,8 @@
         </activity>
         <activity
             android:name="com.github.pockethub.ui.issue.EditIssuesFilterActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize">
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:label="@string/filter_issues_title">
             <intent-filter>
                 <action android:name="com.github.pockethub.repo.issues.filter.VIEW" />
 
@@ -102,6 +103,7 @@
         </activity>
         <activity
             android:name="com.github.pockethub.ui.issue.FiltersViewActivity"
+            android:label="@string/bookmarks"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:hardwareAccelerated="true">
             <intent-filter>

--- a/app/src/main/java/com/github/pockethub/ui/gist/CreateGistActivity.java
+++ b/app/src/main/java/com/github/pockethub/ui/gist/CreateGistActivity.java
@@ -64,7 +64,6 @@ public class CreateGistActivity extends BaseActivity {
         publicCheckBox = finder.find(R.id.cb_public);
 
         ActionBar actionBar = getSupportActionBar();
-        actionBar.setTitle(R.string.new_gist);
         actionBar.setIcon(R.drawable.ic_github_gist_white_32dp);
         actionBar.setDisplayHomeAsUpEnabled(true);
 

--- a/app/src/main/java/com/github/pockethub/ui/issue/EditIssuesFilterActivity.java
+++ b/app/src/main/java/com/github/pockethub/ui/issue/EditIssuesFilterActivity.java
@@ -122,7 +122,6 @@ public class EditIssuesFilterActivity extends DialogFragmentActivity {
         setSupportActionBar((android.support.v7.widget.Toolbar) findViewById(R.id.toolbar));
 
         ActionBar actionBar = getSupportActionBar();
-        actionBar.setTitle(R.string.filter_issues_title);
         actionBar.setSubtitle(InfoUtils.createRepoId(repository));
         avatars.bind(actionBar, repository.owner);
 

--- a/app/src/main/java/com/github/pockethub/ui/issue/FiltersViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/ui/issue/FiltersViewActivity.java
@@ -68,7 +68,6 @@ public class FiltersViewActivity extends DialogFragmentActivity implements
         setSupportActionBar((android.support.v7.widget.Toolbar) findViewById(R.id.toolbar));
 
         ActionBar actionBar = getSupportActionBar();
-        actionBar.setTitle(R.string.bookmarks);
         actionBar.setIcon(R.drawable.ic_bookmark_white_24dp);
         actionBar.setDisplayHomeAsUpEnabled(true);
 


### PR DESCRIPTION
as mentioned here: https://github.com/pockethub/PocketHub/pull/937#discussion_r45508911

The titles of the other acitivities are dynamic, so it doesn't make sense to set labels for them

more information: http://developer.android.com/guide/topics/manifest/activity-element.html#label