### PR TITLE
Update lint rules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,10 @@ android {
 
     lintOptions {
         warning 'MissingTranslation'
-        abortOnError false
+        abortOnError true
+        check 'NewApi', 'InlinedApi'
+        fatal 'NewApi', 'InlinedApi'
+        checkReleaseBuilds true
         
         textReport isTravis
         textOutput 'stdout'

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2015 PocketHub
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<lint>
+    <!-- These were fixed in build tools 22 -->
+    <issue id="NewApi" severity="error">
+        <ignore regexp=".*paddingStart.*" />
+    </issue>
+</lint>


### PR DESCRIPTION
We want API errors linted, but also to ignore paddingStart issues. Looks like google finally fixed this lint since build tools 22+ fixes this, but will see what travis says about lints