### PR TITLE
Smooth Navigation

### DIFF
--- a/app/src/main/java/com/github/pockethub/ui/ItemListFragment.java
+++ b/app/src/main/java/com/github/pockethub/ui/ItemListFragment.java
@@ -160,13 +160,7 @@ public abstract class ItemListFragment<E> extends DialogFragment implements
 
         configureList(getActivity(), getListView());
     }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        refreshWithProgress();
-    }
-
+    
     /**
      * Configure list after view has been created
      *


### PR DESCRIPTION
Removed refresh `onResume()` for `ViewPager` items. This makes the in-app-navigation a lot better.  

Before             |  After
:-------------------------:|:-------------------------:
![screen-recording_20160307-170453](https://cloud.githubusercontent.com/assets/4983347/13569279/1f7ee78a-e48d-11e5-8f06-303557f1d033.gif)  | ![screen-recording_20160307-171155](https://cloud.githubusercontent.com/assets/4983347/13569410/f781ba0e-e48d-11e5-87e2-d2a3c758b33f.gif)
![ezgif com-resize 1](https://cloud.githubusercontent.com/assets/4983347/13569566/b8a91c2c-e48e-11e5-952c-37d968575837.gif) | ![screen-recording_20160307-171226](https://cloud.githubusercontent.com/assets/4983347/13569716/a3ca13c8-e48f-11e5-8632-9877fd59b3f0.gif)
