### PR TITLE
Implemented Readme for repositories

### DIFF
--- a/app/src/main/assets/github.css
+++ b/app/src/main/assets/github.css
@@ -1,0 +1,362 @@
+body {
+    font-family: Helvetica, arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.6;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    background-color: white;
+    padding: 20px;
+    word-wrap: break-word;
+}
+body > *:first-child {
+    margin-top: 0 !important;
+}
+body > *:last-child {
+    margin-bottom: 0 !important;
+}
+a {
+    color: #4183C4;
+}
+a.absent {
+    color: #cc0000;
+}
+a.anchor {
+    display: block;
+    padding-left: 30px;
+    margin-left: -30px;
+    cursor: pointer;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    margin: 20px 0 10px;
+    padding: 0;
+    font-weight: bold;
+    -webkit-font-smoothing: antialiased;
+    cursor: text;
+    position: relative;
+}
+h1:hover a.anchor,
+h2:hover a.anchor,
+h3:hover a.anchor,
+h4:hover a.anchor,
+h5:hover a.anchor,
+h6:hover a.anchor {
+    background: url("../../images/modules/styleguide/para.png") no-repeat 10px center;
+    text-decoration: none;
+}
+h1 tt,
+h1 code {
+    font-size: inherit;
+}
+h2 tt,
+h2 code {
+    font-size: inherit;
+}
+h3 tt,
+h3 code {
+    font-size: inherit;
+}
+h4 tt,
+h4 code {
+    font-size: inherit;
+}
+h5 tt,
+h5 code {
+    font-size: inherit;
+}
+h6 tt,
+h6 code {
+    font-size: inherit;
+}
+h1 {
+    font-size: 28px;
+    color: black;
+}
+h2 {
+    font-size: 24px;
+    border-bottom: 1px solid #cccccc;
+    color: black;
+}
+h3 {
+    font-size: 18px;
+}
+h4 {
+    font-size: 16px;
+}
+h5 {
+    font-size: 14px;
+}
+h6 {
+    color: #777777;
+    font-size: 14px;
+}
+p,
+blockquote,
+ul,
+ol,
+dl,
+li,
+table,
+pre {
+    margin: 15px 0;
+}
+hr {
+    background: transparent url("../../images/modules/pulls/dirty-shade.png") repeat-x 0 0;
+    border: 0 none;
+    color: #cccccc;
+    height: 4px;
+    padding: 0;
+}
+body > h2:first-child {
+    margin-top: 0;
+    padding-top: 0;
+}
+body > h1:first-child {
+    margin-top: 0;
+    padding-top: 0;
+}
+body > h1:first-child + h2 {
+    margin-top: 0;
+    padding-top: 0;
+}
+body > h3:first-child,
+body > h4:first-child,
+body > h5:first-child,
+body > h6:first-child {
+    margin-top: 0;
+    padding-top: 0;
+}
+a:first-child h1,
+a:first-child h2,
+a:first-child h3,
+a:first-child h4,
+a:first-child h5,
+a:first-child h6 {
+    margin-top: 0;
+    padding-top: 0;
+}
+h1 p,
+h2 p,
+h3 p,
+h4 p,
+h5 p,
+h6 p {
+    margin-top: 0;
+}
+li p.first {
+    display: inline-block;
+}
+ul,
+ol {
+    padding-left: 30px;
+}
+ul:first-child,
+ol:first-child {
+    margin-top: 0;
+}
+ul:last-child,
+ol:last-child {
+    margin-bottom: 0;
+}
+dl {
+    padding: 0;
+}
+dl dt {
+    font-size: 14px;
+    font-weight: bold;
+    font-style: italic;
+    padding: 0;
+    margin: 15px 0 5px;
+}
+dl dt:first-child {
+    padding: 0;
+}
+dl dt >:first-child {
+    margin-top: 0;
+}
+dl dt >:last-child {
+    margin-bottom: 0;
+}
+dl dd {
+    margin: 0 0 15px;
+    padding: 0 15px;
+}
+dl dd >:first-child {
+    margin-top: 0;
+}
+dl dd >:last-child {
+    margin-bottom: 0;
+}
+blockquote {
+    border-left: 4px solid #dddddd;
+    padding: 0 15px;
+    color: #777777;
+}
+blockquote >:first-child {
+    margin-top: 0;
+}
+blockquote >:last-child {
+    margin-bottom: 0;
+}
+table {
+    padding: 0;
+    display: block;
+    overflow: auto;
+    word-break: keep-all;
+    width: 100%;
+    border-spacing: 0;
+    border-collapse: collapse;
+}
+table tr {
+    border-top: 1px solid #cccccc;
+    background-color: white;
+    margin: 0;
+    padding: 0;
+}
+table tr:nth-child(2n) {
+    background-color: #f8f8f8;
+}
+table tr th {
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 6px 13px;
+}
+table tr td {
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 6px 13px;
+}
+table tr th:first-child,
+table tr td:first-child {
+    margin-top: 0;
+}
+table tr th:last-child,
+table tr td:last-child {
+    margin-bottom: 0;
+}
+img {
+    max-width: 100%;
+}
+span.frame {
+    display: block;
+    overflow: hidden;
+}
+span.frame > span {
+    border: 1px solid #dddddd;
+    display: block;
+    float: left;
+    overflow: hidden;
+    margin: 13px 0 0;
+    padding: 7px;
+    width: auto;
+}
+span.frame span img {
+    display: block;
+    float: left;
+}
+span.frame span span {
+    clear: both;
+    color: #333333;
+    display: block;
+    padding: 5px 0 0;
+}
+span.align-center {
+    display: block;
+    overflow: hidden;
+    clear: both;
+}
+span.align-center > span {
+    display: block;
+    overflow: hidden;
+    margin: 13px auto 0;
+    text-align: center;
+}
+span.align-center span img {
+    margin: 0 auto;
+    text-align: center;
+}
+span.align-right {
+    display: block;
+    overflow: hidden;
+    clear: both;
+}
+span.align-right > span {
+    display: block;
+    overflow: hidden;
+    margin: 13px 0 0;
+    text-align: right;
+}
+span.align-right span img {
+    margin: 0;
+    text-align: right;
+}
+span.float-left {
+    display: block;
+    margin-right: 13px;
+    overflow: hidden;
+    float: left;
+}
+span.float-left span {
+    margin: 13px 0 0;
+}
+span.float-right {
+    display: block;
+    margin-left: 13px;
+    overflow: hidden;
+    float: right;
+}
+span.float-right > span {
+    display: block;
+    overflow: hidden;
+    margin: 13px auto 0;
+    text-align: right;
+}
+code,
+tt {
+    margin: 0 2px;
+    padding: 0 5px;
+    white-space: nowrap;
+    border: 1px solid #eaeaea;
+    background-color: #f8f8f8;
+    border-radius: 3px;
+}
+pre code {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+}
+.highlight pre {
+    background-color: #f8f8f8;
+    border: 1px solid #cccccc;
+    font-size: 13px;
+    line-height: 19px;
+    overflow: auto;
+    padding: 6px 10px;
+    border-radius: 3px;
+}
+pre {
+    background-color: #f8f8f8;
+    border: 1px solid #cccccc;
+    font-size: 13px;
+    line-height: 19px;
+    overflow: auto;
+    padding: 6px 10px;
+    border-radius: 3px;
+}
+pre code,
+pre tt {
+    background-color: transparent;
+    border: none;
+}

--- a/app/src/main/assets/intercept.js
+++ b/app/src/main/assets/intercept.js
@@ -1,0 +1,21 @@
+window.onload = function(){
+    addTouchEvents(document.getElementsByTagName("pre"));
+    addTouchEvents(document.getElementsByTagName("table"));
+};
+
+function addTouchEvents(elements){
+    for(var i = 0; i < elements.length; i++){
+        elements[i].addEventListener("touchstart", touchStart, false);
+        elements[i].addEventListener("touchend", touchEnd, false);
+    }
+}
+
+function touchStart(event){
+    //if(event.target.scrollWidth > event.target.clientWidth)
+        Readme.startIntercept();
+}
+
+function touchEnd(event){
+    //if(event.target.scrollWidth > event.target.clientWidth)
+        Readme.stopIntercept();
+}

--- a/app/src/main/java/com/github/pockethub/api/CheckHasReadMeClient.java
+++ b/app/src/main/java/com/github/pockethub/api/CheckHasReadMeClient.java
@@ -20,6 +20,6 @@ public class CheckHasReadMeClient extends GithubClient<Response> {
 
     @Override
     protected Observable<Response> getApiObservable(RestAdapter restAdapter) {
-        return restAdapter.create(ContentService.class).hasReadme(info.owner, info.owner);
+        return restAdapter.create(ContentService.class).hasReadme(info.owner, info.name);
     }
 }

--- a/app/src/main/java/com/github/pockethub/api/CheckHasReadMeClient.java
+++ b/app/src/main/java/com/github/pockethub/api/CheckHasReadMeClient.java
@@ -1,0 +1,25 @@
+package com.github.pockethub.api;
+
+import com.alorma.github.sdk.bean.info.RepoInfo;
+import com.alorma.github.sdk.services.client.GithubClient;
+
+import retrofit.RestAdapter;
+import retrofit.client.Response;
+import rx.Observable;
+
+/**
+ * Created by Henrik on 16-06-13.
+ */
+public class CheckHasReadMeClient extends GithubClient<Response> {
+
+    private RepoInfo info;
+
+    public CheckHasReadMeClient(RepoInfo info) {
+        this.info = info;
+    }
+
+    @Override
+    protected Observable<Response> getApiObservable(RestAdapter restAdapter) {
+        return restAdapter.create(ContentService.class).hasReadme(info.owner, info.owner);
+    }
+}

--- a/app/src/main/java/com/github/pockethub/api/CheckHasReadMeClient.java
+++ b/app/src/main/java/com/github/pockethub/api/CheckHasReadMeClient.java
@@ -7,9 +7,6 @@ import retrofit.RestAdapter;
 import retrofit.client.Response;
 import rx.Observable;
 
-/**
- * Created by Henrik on 16-06-13.
- */
 public class CheckHasReadMeClient extends GithubClient<Response> {
 
     private RepoInfo info;

--- a/app/src/main/java/com/github/pockethub/api/ContentService.java
+++ b/app/src/main/java/com/github/pockethub/api/ContentService.java
@@ -6,9 +6,6 @@ import retrofit.http.HEAD;
 import retrofit.http.Path;
 import rx.Observable;
 
-/**
- * Created by Henrik on 16-06-13.
- */
 public interface ContentService {
 
     /**

--- a/app/src/main/java/com/github/pockethub/api/ContentService.java
+++ b/app/src/main/java/com/github/pockethub/api/ContentService.java
@@ -1,0 +1,24 @@
+package com.github.pockethub.api;
+
+import retrofit.client.Response;
+import retrofit.http.GET;
+import retrofit.http.HEAD;
+import retrofit.http.Path;
+import rx.Observable;
+
+/**
+ * Created by Henrik on 16-06-13.
+ */
+public interface ContentService {
+
+    /**
+     * Get's readme content. Note it's a HTTP HEAD so only headers will be returned for checking
+     * the existences
+     * @param owner
+     * @param repo
+     * @return
+     */
+    @HEAD("/repos/{owner}/{repo}/readme")
+    Observable<Response> hasReadme(@Path("owner") String owner, @Path("repo") String repo);
+
+}

--- a/app/src/main/java/com/github/pockethub/ui/WebView.java
+++ b/app/src/main/java/com/github/pockethub/ui/WebView.java
@@ -17,11 +17,14 @@ package com.github.pockethub.ui;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.MotionEvent;
 
 /**
  * Web view extension with scrolling fixes
  */
 public class WebView extends android.webkit.WebView {
+
+    private boolean intercept;
 
     /**
      * @param context
@@ -59,6 +62,20 @@ public class WebView extends android.webkit.WebView {
         super(context);
     }
 
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent p_event)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent p_event) {
+        if (intercept && getParent() != null)
+            getParent().requestDisallowInterceptTouchEvent(true);
+
+        return super.onTouchEvent(p_event);
+    }
+
     private boolean canScrollCodeHorizontally(final int direction) {
         final int range = computeHorizontalScrollRange()
                 - computeHorizontalScrollExtent();
@@ -74,5 +91,13 @@ public class WebView extends android.webkit.WebView {
     @Override
     public boolean canScrollHorizontally(final int direction) {
         return super.canScrollHorizontally(direction);
+    }
+
+    public void startIntercept() {
+        intercept = true;
+    }
+
+    public void stopIntercept() {
+        intercept = false;
     }
 }

--- a/app/src/main/java/com/github/pockethub/ui/repo/RepositoryPagerAdapter.java
+++ b/app/src/main/java/com/github/pockethub/ui/repo/RepositoryPagerAdapter.java
@@ -31,19 +31,11 @@ import com.github.pockethub.ui.issue.IssuesFragment;
  */
 public class RepositoryPagerAdapter extends FragmentPagerAdapter {
 
-    /**
-     * Index of code page
-     */
-    public static final int ITEM_CODE = 2;
-
-    /**
-     * Index of commits page
-     */
-    public static final int ITEM_COMMITS = 3;
-
     private final Resources resources;
 
     private final boolean hasIssues;
+
+    private final boolean hasReadme;
 
     private RepositoryCodeFragment codeFragment;
 
@@ -56,15 +48,18 @@ public class RepositoryPagerAdapter extends FragmentPagerAdapter {
      * @param hasIssues
      */
     public RepositoryPagerAdapter(AppCompatActivity activity,
-                                  boolean hasIssues) {
+                                  boolean hasIssues, boolean hasReadme) {
         super(activity);
 
         resources = activity.getResources();
+        this.hasReadme = hasReadme;
         this.hasIssues = hasIssues;
     }
 
     @Override
     public CharSequence getPageTitle(int position) {
+        position = hasReadme ? position : position + 1;
+
         switch (position) {
             case 0:
                 return resources.getString(R.string.tab_readme);
@@ -83,6 +78,8 @@ public class RepositoryPagerAdapter extends FragmentPagerAdapter {
 
     @Override
     public Fragment getItem(int position) {
+        position = hasReadme ? position : position + 1;
+
         switch (position) {
             case 0:
                 return new RepositoryReadmeFragment();
@@ -103,7 +100,24 @@ public class RepositoryPagerAdapter extends FragmentPagerAdapter {
 
     @Override
     public int getCount() {
-        return hasIssues ? 5 : 4;
+        int count = hasIssues ? 5 : 4;
+        count = hasReadme ? count : count - 1;
+
+        return count;
+    }
+
+    /**
+     * Returns index of code page
+     */
+    public int getItemCode() {
+        return hasReadme ? 2 : 1;
+    }
+
+    /**
+     * Returns index of commits page
+     */
+    public int getItemCommits() {
+        return hasReadme ? 3 : 2;
     }
 
     /**
@@ -126,9 +140,9 @@ public class RepositoryPagerAdapter extends FragmentPagerAdapter {
      */
     public RepositoryPagerAdapter onDialogResult(int position, int requestCode,
                                                  int resultCode, Bundle arguments) {
-        if (position == ITEM_CODE && codeFragment != null)
+        if (position == getItemCode() && codeFragment != null)
             codeFragment.onDialogResult(requestCode, resultCode, arguments);
-        else if (position == ITEM_COMMITS && commitsFragment != null)
+        else if (position == getItemCommits() && commitsFragment != null)
             commitsFragment.onDialogResult(requestCode, resultCode, arguments);
 
         return this;

--- a/app/src/main/java/com/github/pockethub/ui/repo/RepositoryPagerAdapter.java
+++ b/app/src/main/java/com/github/pockethub/ui/repo/RepositoryPagerAdapter.java
@@ -34,12 +34,12 @@ public class RepositoryPagerAdapter extends FragmentPagerAdapter {
     /**
      * Index of code page
      */
-    public static final int ITEM_CODE = 1;
+    public static final int ITEM_CODE = 2;
 
     /**
      * Index of commits page
      */
-    public static final int ITEM_COMMITS = 2;
+    public static final int ITEM_COMMITS = 3;
 
     private final Resources resources;
 
@@ -56,7 +56,7 @@ public class RepositoryPagerAdapter extends FragmentPagerAdapter {
      * @param hasIssues
      */
     public RepositoryPagerAdapter(AppCompatActivity activity,
-            boolean hasIssues) {
+                                  boolean hasIssues) {
         super(activity);
 
         resources = activity.getResources();
@@ -66,40 +66,44 @@ public class RepositoryPagerAdapter extends FragmentPagerAdapter {
     @Override
     public CharSequence getPageTitle(int position) {
         switch (position) {
-        case 0:
-            return resources.getString(R.string.tab_news);
-        case 1:
-            return resources.getString(R.string.tab_code);
-        case 2:
-            return resources.getString(R.string.tab_commits);
-        case 3:
-            return resources.getString(R.string.tab_issues);
-        default:
-            return null;
+            case 0:
+                return resources.getString(R.string.tab_readme);
+            case 1:
+                return resources.getString(R.string.tab_news);
+            case 2:
+                return resources.getString(R.string.tab_code);
+            case 3:
+                return resources.getString(R.string.tab_commits);
+            case 4:
+                return resources.getString(R.string.tab_issues);
+            default:
+                return null;
         }
     }
 
     @Override
     public Fragment getItem(int position) {
         switch (position) {
-        case 0:
-            return new RepositoryNewsFragment();
-        case 1:
-            codeFragment = new RepositoryCodeFragment();
-            return codeFragment;
-        case 2:
-            commitsFragment = new CommitListFragment();
-            return commitsFragment;
-        case 3:
-            return new IssuesFragment();
-        default:
-            return null;
+            case 0:
+                return new RepositoryReadmeFragment();
+            case 1:
+                return new RepositoryNewsFragment();
+            case 2:
+                codeFragment = new RepositoryCodeFragment();
+                return codeFragment;
+            case 3:
+                commitsFragment = new CommitListFragment();
+                return commitsFragment;
+            case 4:
+                return new IssuesFragment();
+            default:
+                return null;
         }
     }
 
     @Override
     public int getCount() {
-        return hasIssues ? 4 : 3;
+        return hasIssues ? 5 : 4;
     }
 
     /**
@@ -121,7 +125,7 @@ public class RepositoryPagerAdapter extends FragmentPagerAdapter {
      * @return this adapter
      */
     public RepositoryPagerAdapter onDialogResult(int position, int requestCode,
-            int resultCode, Bundle arguments) {
+                                                 int resultCode, Bundle arguments) {
         if (position == ITEM_CODE && codeFragment != null)
             codeFragment.onDialogResult(requestCode, resultCode, arguments);
         else if (position == ITEM_COMMITS && commitsFragment != null)

--- a/app/src/main/java/com/github/pockethub/ui/repo/RepositoryReadmeFragment.java
+++ b/app/src/main/java/com/github/pockethub/ui/repo/RepositoryReadmeFragment.java
@@ -1,0 +1,75 @@
+package com.github.pockethub.ui.repo;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebSettings;
+import android.widget.Toast;
+
+import com.alorma.github.sdk.bean.dto.response.Repo;
+import com.alorma.github.sdk.services.repo.GetReadmeContentsClient;
+import com.github.pockethub.Intents;
+import com.github.pockethub.rx.ObserverAdapter;
+import com.github.pockethub.ui.DialogFragment;
+import com.github.pockethub.ui.WebView;
+import com.github.pockethub.util.InfoUtils;
+
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
+
+public class RepositoryReadmeFragment extends DialogFragment {
+
+    private static final String PAGE_START = "<!DOCTYPE html><html lang=\"en\"> <head> <title></title>" +
+            "<meta charset=\"UTF-8\"> " +
+            "<meta name=\"viewport\" content=\"width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;\"/>" +
+            "<script src=\"intercept.js\"></script>" +
+            "<link href=\"github.css\" rel=\"stylesheet\"> </head> <body>";
+
+    private static final String PAGE_END = "</body></html>";
+    private WebView webview;
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return new WebView(getActivity());
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        webview = (WebView) view;
+
+        Repo repo = getParcelableExtra(Intents.EXTRA_REPOSITORY);
+        WebSettings settings = webview.getSettings();
+        settings.setJavaScriptEnabled(true);
+        webview.addJavascriptInterface(this, "Readme");
+
+        new GetReadmeContentsClient(InfoUtils.createRepoInfo(repo))
+                .observable()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .compose(this.<String>bindToLifecycle())
+                .subscribe(new ObserverAdapter<String>() {
+                    @Override
+                    public void onNext(String s) {
+                        super.onNext(s);
+                        String data = PAGE_START + s + PAGE_END;
+                        webview.loadDataWithBaseURL("file:///android_asset/", data, "text/html", "UTF-8", null);
+                    }
+                });
+    }
+
+    @JavascriptInterface
+    public void startIntercept() {
+        webview.startIntercept();
+    }
+
+    @JavascriptInterface
+    public void stopIntercept() {
+        webview.stopIntercept();
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -282,6 +282,7 @@
     <string name="tab_mentioned">mentioned</string>
     <string name="tab_mine">mine</string>
     <string name="tab_starred">starred</string>
+    <string name="tab_readme">readme</string>
     <string name="tab_all">all</string>
     <!--  -->
     <string name="share">Share</string>


### PR DESCRIPTION
There are workarounds for viewpager scrolling in intercept.js. 
The CSS resembles the GitHub rendering.

How the repository view looks now:
![screenshot_20160603-202919](https://cloud.githubusercontent.com/assets/3757908/15788988/62b45d28-29ca-11e6-8bf8-32db0af059d7.png)
