### PR TITLE
Update RxJava dependency / simplify support update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,8 +113,8 @@ dependencies {
     compile 'com.squareup.retrofit:retrofit:1.9.0'
 
     compile 'com.github.alorma:github-sdk:3.2.5'
-    compile 'io.reactivex:rxandroid:1.1.0'
-    compile 'io.reactivex:rxjava:1.1.0'
+    compile 'io.reactivex:rxandroid:1.2.1'
+    compile 'io.reactivex:rxjava:1.2.0'
     compile 'com.trello:rxlifecycle:0.4.0'
     compile 'com.bugsnag:bugsnag-android:3.2.7'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,9 +101,11 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:support-v4:23.4.0'
-    compile 'com.android.support:design:23.4.0'
+
+    def supportVersion = '23.4.0'
+    compile "com.android.support:appcompat-v7:$supportVersion"
+    compile "com.android.support:support-v4:$supportVersion"
+    compile "com.android.support:design:$supportVersion"
 
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.squareup.okhttp:okhttp:2.7.0'


### PR DESCRIPTION
Hey there,

I've updated the RxJava deps.
Also extract a android support lib version number to update these libs with a one liner 👍 

I've also tried to update okhttp and retrofit but currently this is impossible because of the `com.github.alorma` dependency (which is currently deprecated :/)