### PR TITLE
Fixed Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: android
 android:
    components:
    - tools
+   - tools
    - platform-tools
    - android-23
    - build-tools-23.0.3
@@ -12,7 +13,7 @@ jdk: oraclejdk7
 notifications:
   email: false
 
-sudo: false
+sudo: required
 
 script:
   - ./gradlew clean build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 android:
    components:
    - tools
-   - tools
+   - tools #Running this twice get's the latest build tools (https://github.com/codepath/android_guides/wiki/Setting-up-Travis-CI)
    - platform-tools
    - android-23
    - build-tools-23.0.3
@@ -13,7 +13,7 @@ jdk: oraclejdk7
 notifications:
   email: false
 
-sudo: required
+sudo: required #The build runs out of memory and is killed if we use the container system
 
 script:
   - ./gradlew clean build


### PR DESCRIPTION
For the moment it seems like we can't use the container infrastructure. The changes made here are based on https://github.com/codepath/android_guides/wiki/Setting-up-Travis-CI