### PR TITLE
Use TimeUnit for self documenting time conversion

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/accounts/LoginActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/accounts/LoginActivity.java
@@ -40,6 +40,8 @@ import com.meisolsson.githubsdk.model.request.RequestToken;
 import com.meisolsson.githubsdk.service.OAuthService;
 import com.meisolsson.githubsdk.service.users.UserService;
 
+import java.util.concurrent.TimeUnit;
+
 import okhttp3.HttpUrl;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
@@ -69,10 +71,7 @@ public class LoginActivity extends RoboAccountAuthenticatorAppCompatActivity {
 
     private static final String TAG = "LoginActivity";
 
-    /**
-     * Sync period in seconds, currently every 8 hours
-     */
-    private static final long SYNC_PERIOD = 8L * 60L * 60L;
+    private static final long SYNC_PERIOD = TimeUnit.HOURS.toSeconds(8);
     private String clientId;
     private String secret;
     private String redirectUri;

--- a/app/src/main/java/com/github/pockethub/android/util/TimeUtils.java
+++ b/app/src/main/java/com/github/pockethub/android/util/TimeUtils.java
@@ -18,6 +18,7 @@ package com.github.pockethub.android.util;
 import android.text.format.DateUtils;
 
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import static android.text.format.DateUtils.FORMAT_NUMERIC_DATE;
 import static android.text.format.DateUtils.FORMAT_SHOW_DATE;
@@ -37,7 +38,7 @@ public class TimeUtils {
      */
     public static CharSequence getRelativeTime(final Date date) {
         long now = System.currentTimeMillis();
-        if (Math.abs(now - date.getTime()) > 60000)
+        if (Math.abs(now - date.getTime()) > TimeUnit.MINUTES.toMillis(1))
             return DateUtils.getRelativeTimeSpanString(date.getTime(), now,
                     MINUTE_IN_MILLIS, FORMAT_SHOW_DATE | FORMAT_SHOW_YEAR
                             | FORMAT_NUMERIC_DATE);


### PR DESCRIPTION
This removes the need for unnecessary comments and magic numbers (for example in `TimeUtils.getRelativeTime(Date)`, the number 60000 corresponding to 1 minute took longer than I'd care to admit).