### PR TITLE
Do case insensitive check on scheme of custom Authorization callback URL.

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/accounts/LoginActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/accounts/LoginActivity.java
@@ -130,7 +130,7 @@ public class LoginActivity extends RoboAccountAuthenticatorAppCompatActivity {
     }
 
     private void onUserLoggedIn(Uri uri) {
-        if (uri != null && uri.getScheme().equals(getString(R.string.github_oauth_scheme))) {
+        if (uri != null && uri.getScheme().equalsIgnoreCase(getString(R.string.github_oauth_scheme))) {
             openLoadingDialog();
             String code = uri.getQueryParameter("code");
             RequestToken request = RequestToken.builder()

--- a/app/src/main/java/com/github/pockethub/android/accounts/LoginWebViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/accounts/LoginWebViewActivity.java
@@ -53,7 +53,7 @@ public class LoginWebViewActivity extends AppCompatActivity {
             @Override
             public boolean shouldOverrideUrlLoading(android.webkit.WebView view, String url) {
                 Uri uri = Uri.parse(url);
-                if (uri.getScheme().equals(getString(R.string.github_oauth_scheme))) {
+                if (uri.getScheme().equalsIgnoreCase(getString(R.string.github_oauth_scheme))) {
                     Intent data = new Intent();
                     data.setData(uri);
                     setResult(RESULT_OK, data);


### PR DESCRIPTION
From Wiki:
Although schemes are case-insensitive, the canonical form is lowercase and documents that specify schemes must do so with lowercase letters.