### PR TITLE
Remove unused method getIssueFilters()

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/persistence/AccountDataManager.java
+++ b/app/src/main/java/com/github/pockethub/android/persistence/AccountDataManager.java
@@ -196,17 +196,6 @@ public class AccountDataManager {
     }
 
     /**
-     * Get bookmarked issue filters
-     *
-     * @param requestConsumer
-     */
-    public void getIssueFilters(
-            final Consumer<Collection<IssueFilter>> requestConsumer) {
-        Single.<Collection<IssueFilter>>create(emitter -> emitter.onSuccess(getIssueFilters()))
-                .subscribe(requestConsumer);
-    }
-
-    /**
      * Add issue filter to store
      * <p/>
      * This method may perform file I/O and should never be called on the


### PR DESCRIPTION
This method could have been replaced with `Single.fromCallable(this::getIssueFilters);` which would return a `Single` making it more flexible than the current implmentation. For future use, the removed method wouldn't have been useful anyway due to the conciseness of the described solution.