### PR TITLE
Call super methods when overriding ProgressObserverAdapter methods wh…

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/rx/ProgressObserverAdapter.java
+++ b/app/src/main/java/com/github/pockethub/android/rx/ProgressObserverAdapter.java
@@ -1,6 +1,7 @@
 package com.github.pockethub.android.rx;
 
 import android.content.Context;
+import android.support.annotation.CallSuper;
 import android.support.annotation.StringRes;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -36,11 +37,13 @@ public class ProgressObserverAdapter<T> implements Observer<T>, SingleObserver<T
         this.message = message;
     }
 
+    @CallSuper
     @Override
     public void onSuccess(T t) {
         onComplete();
     }
 
+    @CallSuper
     @Override
     public void onComplete() {
         dismissProgress();
@@ -54,6 +57,7 @@ public class ProgressObserverAdapter<T> implements Observer<T>, SingleObserver<T
     public void onNext(final T t) {
     }
 
+    @CallSuper
     @Override
     public void onError(Throwable e) {
         dismissProgress();

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/EditCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/EditCommentActivity.java
@@ -106,7 +106,6 @@ public class EditCommentActivity extends
                     @Override
                     public void onSuccess(Response<GitHubComment> response) {
                         super.onSuccess(response);
-                        dismissProgress();
                         finish(response.body());
                     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.java
@@ -187,7 +187,6 @@ public class GistsViewActivity extends PagerActivity implements
                             super.onError(e);
                             Log.d(TAG, "Exception deleting Gist", e);
                             ToastUtils.show(GistsViewActivity.this, e.getMessage());
-                            dismissProgress();
                         }
                     }.start());
             return;

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/AssigneeDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/AssigneeDialog.java
@@ -75,7 +75,7 @@ public class AssigneeDialog extends BaseProgressDialog {
 
             @Override
             public void onError(Throwable error) {
-                dismissProgress();
+                super.onError(error);
                 Log.d(TAG, "Exception loading collaborators", error);
                 ToastUtils.show(activity, error, R.string.error_collaborators_load);
             }
@@ -90,7 +90,6 @@ public class AssigneeDialog extends BaseProgressDialog {
                 }
                 collaborators = loadedCollaborators;
 
-                dismissProgress();
                 show(selectedAssignee);
             }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditCommentActivity.java
@@ -118,7 +118,6 @@ public class EditCommentActivity extends
                     @Override
                     public void onSuccess(Response<GitHubComment> response) {
                         super.onSuccess(response);
-                        dismissProgress();
                         finish(response.body());
                     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
@@ -508,6 +508,7 @@ public class IssueFragment extends DialogFragment {
 
                         @Override
                         public void onSuccess(Response<Boolean> response) {
+                            super.onSuccess(response);
                             if (items != null) {
                                 int commentPosition = findCommentPositionInItems(comment);
                                 if (commentPosition >= 0) {
@@ -518,14 +519,13 @@ public class IssueFragment extends DialogFragment {
                             } else {
                                 refreshIssue();
                             }
-                            dismissProgress();
                         }
 
                         @Override
                         public void onError(Throwable e) {
+                            super.onError(e);
                             Log.d(TAG, "Exception deleting comment on issue", e);
                             ToastUtils.show(getActivity(), e.getMessage());
-                            dismissProgress();
                         }
                     }.start());
             break;

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/LabelsDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/LabelsDialog.java
@@ -92,13 +92,12 @@ public class LabelsDialog extends BaseProgressDialog {
 
                 labels = loadedLabels;
 
-                dismissProgress();
                 show(selectedLabels);
             }
 
             @Override
             public void onError(Throwable error) {
-                dismissProgress();
+                super.onError(error);
                 Log.e(TAG, "Exception loading labels", error);
                 ToastUtils.show(activity, error, R.string.error_labels_load);
             }

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/MilestoneDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/MilestoneDialog.java
@@ -93,13 +93,12 @@ public class MilestoneDialog extends BaseProgressDialog {
                         CASE_INSENSITIVE_ORDER.compare(m1.title(), m2.title()));
                 repositoryMilestones = milestones;
 
-                dismissProgress();
                 show(selectedMilestone);
             }
 
             @Override
             public void onError(Throwable error) {
-                dismissProgress();
+                super.onError(error);
                 Log.e(TAG, "Exception loading milestones", error);
                 ToastUtils.show(activity, error, R.string.error_milestones_load);
             }


### PR DESCRIPTION
…ere parent class method isn't empty.

All calls to `ProgressOberverAdapter#dismissProgress` from implementing classes are now redundant with use of `super`.