### PR TITLE
Remove checks for null in onNext as emitted items never null

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFileFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFileFragment.java
@@ -162,10 +162,6 @@ public class GistFileFragment extends DialogFragment implements
         }).subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(loadedFile -> {
-                    if (loadedFile == null) {
-                        return;
-                    }
-
                     file = loadedFile;
                     getArguments().putParcelable(EXTRA_GIST_FILE, file);
                     if (file.content() != null) {

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.java
@@ -283,11 +283,7 @@ public class RepositoryViewActivity extends TabPagerActivity<RepositoryPagerAdap
                 .compose(this.bindToLifecycle())
                 .subscribe(response -> {
                     Repository repo = response.body();
-                    if (repo != null) {
-                        UriLauncherActivity.launchUri(this, Uri.parse(repo.htmlUrl()));
-                    } else {
-                        ToastUtils.show(this, R.string.error_forking_repository);
-                    }
+                    UriLauncherActivity.launchUri(this, Uri.parse(repo.htmlUrl()));
                 }, e -> ToastUtils.show(this, R.string.error_forking_repository));
     }
 


### PR DESCRIPTION
`null` can never be omitted from the stream as per the [documentation](https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#nulls). Such `null` checks are redundant and are removed in this PR.

Neither of the two modified streams should encounter any logical differences though as the null check for `GistFileFragment#loadSource(…)` is done [here](https://github.com/pockethub/PocketHub/compare/master...veyndan:onNext-null?expand=1#diff-3383463dc03986077aa21aafd5aba0fbL155) and in `RepositoryViewActivity#forkRepository` the `else` clause [here](https://github.com/pockethub/PocketHub/compare/master...veyndan:onNext-null?expand=1#diff-0147304db06ca1aa4e9e22999bfc6eb0L288) is equivalent to its `onError(…)`. This means that if there is a `null` in the stream, `onError(…)` would be called and the same code would be executed.