### PR TITLE
Change AvatarLoader to singleton instance.

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/util/AvatarLoader.java
+++ b/app/src/main/java/com/github/pockethub/android/util/AvatarLoader.java
@@ -28,6 +28,7 @@ import android.view.MenuItem;
 import android.widget.ImageView;
 
 import com.github.pockethub.android.R;
+import com.google.inject.Singleton;
 import com.meisolsson.githubsdk.model.User;
 import com.google.inject.Inject;
 import com.squareup.okhttp.Cache;
@@ -47,6 +48,7 @@ import roboguice.util.RoboAsyncTask;
 /**
  * Avatar utilities
  */
+@Singleton
 public class AvatarLoader {
     static final int DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50MB
 
@@ -73,7 +75,7 @@ public class AvatarLoader {
      */
     @Inject
     public AvatarLoader(final Context context) {
-        this.context = context;
+        this.context = context.getApplicationContext();
 
         OkHttpClient client = new OkHttpClient();
 


### PR DESCRIPTION
App doesn't need many AvatarLoader instance, so make it singleton. 

The risk for this pr which I can think:
1. Memory leak
- I changed the constructor to store Application context, so it won't make other context obj leaked when init it on the first time.
2. Different Context may have different behavior when load avatar.
- Didn't see any usage.
