### PR TITLE
Remove all uses of ViewUtils.setGone(…)

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/ItemListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/ItemListFragment.java
@@ -31,7 +31,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.github.kevinsawicki.wishlist.SingleTypeAdapter;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.ThrowableLoader;
 import com.github.pockethub.android.util.ToastUtils;
@@ -338,12 +337,12 @@ public abstract class ItemListFragment<E> extends DialogFragment implements
     }
 
     private ItemListFragment<E> show(final View view) {
-        ViewUtils.setGone(view, false);
+        view.setVisibility(View.VISIBLE);
         return this;
     }
 
     private ItemListFragment<E> hide(final View view) {
-        ViewUtils.setGone(view, true);
+        view.setVisibility(View.GONE);
         return this;
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/TabPagerActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/TabPagerActivity.java
@@ -22,7 +22,6 @@ import android.view.View;
 import android.widget.TabHost.OnTabChangeListener;
 import android.widget.TabHost.TabContentFactory;
 
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 
 /**
@@ -59,7 +58,9 @@ public abstract class TabPagerActivity<V extends PagerAdapter & FragmentProvider
 
     @Override
     public View createTabContent(String tag) {
-        return ViewUtils.setGone(new View(getApplication()), true);
+        View view = new View(getApplication());
+        view.setVisibility(View.GONE);
+        return view;
     }
 
     /**
@@ -96,8 +97,13 @@ public abstract class TabPagerActivity<V extends PagerAdapter & FragmentProvider
      * @return this activity
      */
     protected TabPagerActivity<V> setGone(boolean gone) {
-        ViewUtils.setGone(slidingTabsLayout, gone);
-        ViewUtils.setGone(pager, gone);
+        if (gone) {
+            slidingTabsLayout.setVisibility(View.GONE);
+            pager.setVisibility(View.GONE);
+        } else {
+            slidingTabsLayout.setVisibility(View.VISIBLE);
+            pager.setVisibility(View.VISIBLE);
+        }
         return this;
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/TabPagerFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/TabPagerFragment.java
@@ -25,7 +25,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 
 import static android.widget.TabHost.OnTabChangeListener;
@@ -61,7 +60,9 @@ public abstract class TabPagerFragment<V extends PagerAdapter & FragmentProvider
 
     @Override
     public View createTabContent(String tag) {
-        return ViewUtils.setGone(new View(getActivity().getApplication()), true);
+        View view = new View(getActivity().getApplication());
+        view.setVisibility(View.GONE);
+        return view;
     }
 
     /**
@@ -98,8 +99,13 @@ public abstract class TabPagerFragment<V extends PagerAdapter & FragmentProvider
      * @return this activity
      */
     protected TabPagerFragment<V> setGone(boolean gone) {
-        ViewUtils.setGone(slidingTabsLayout, gone);
-        ViewUtils.setGone(pager, gone);
+        if (gone) {
+            slidingTabsLayout.setVisibility(View.GONE);
+            pager.setVisibility(View.GONE);
+        } else {
+            slidingTabsLayout.setVisibility(View.VISIBLE);
+            pager.setVisibility(View.VISIBLE);
+        }
         return this;
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.java
@@ -32,7 +32,6 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.code.FullTree;
 import com.github.pockethub.android.core.code.FullTree.Entry;
@@ -137,9 +136,15 @@ public class RepositoryCodeFragment extends DialogFragment implements
     }
 
     private void showLoading(final boolean loading) {
-        ViewUtils.setGone(progressView, !loading);
-        ViewUtils.setGone(listView, loading);
-        ViewUtils.setGone(branchFooterView, loading);
+        if (loading) {
+            progressView.setVisibility(View.VISIBLE);
+            listView.setVisibility(View.GONE);
+            branchFooterView.setVisibility(View.GONE);
+        } else {
+            progressView.setVisibility(View.GONE);
+            listView.setVisibility(View.VISIBLE);
+            branchFooterView.setVisibility(View.VISIBLE);
+        }
     }
 
     private void refreshTree(final GitReference reference) {

--- a/app/src/main/java/com/github/pockethub/android/ui/comment/RenderedCommentFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/comment/RenderedCommentFragment.java
@@ -25,7 +25,6 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.github.kevinsawicki.wishlist.Keyboard;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.ui.DialogFragment;
 import com.github.pockethub.android.ui.MarkdownLoader;
@@ -79,8 +78,13 @@ public class RenderedCommentFragment extends DialogFragment implements
     }
 
     private void showLoading(final boolean loading) {
-        ViewUtils.setGone(progress, !loading);
-        ViewUtils.setGone(bodyText, loading);
+        if (loading) {
+            progress.setVisibility(View.VISIBLE);
+            bodyText.setVisibility(View.GONE);
+        } else {
+            progress.setVisibility(View.GONE);
+            bodyText.setVisibility(View.VISIBLE);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareListFragment.java
@@ -31,7 +31,6 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.commit.CommitUtils;
 import com.github.pockethub.android.ui.DialogFragment;
@@ -146,8 +145,8 @@ public class CommitCompareListFragment extends DialogFragment implements
 
         this.compare = compare;
 
-        ViewUtils.setGone(progress, true);
-        ViewUtils.setGone(list, false);
+        progress.setVisibility(View.GONE);
+        list.setVisibility(View.VISIBLE);
 
         LayoutInflater inflater = getActivity().getLayoutInflater();
         adapter.clearHeaders();

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitDiffListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitDiffListFragment.java
@@ -40,7 +40,6 @@ import com.meisolsson.githubsdk.model.Commit;
 import com.meisolsson.githubsdk.model.GitHubFile;
 import com.meisolsson.githubsdk.model.Repository;
 import com.github.kevinsawicki.wishlist.ViewFinder;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.commit.CommitStore;
 import com.github.pockethub.android.core.commit.CommitUtils;
@@ -254,7 +253,7 @@ public class CommitDiffListFragment extends DialogFragment implements
                     updateList(full.getCommit(), full, full.getFiles());
                 }, e -> {
                     ToastUtils.show(getActivity(), e, R.string.error_commit_load);
-                    ViewUtils.setGone(progress, true);
+                    progress.setVisibility(View.GONE);
                 });
     }
 
@@ -283,9 +282,9 @@ public class CommitDiffListFragment extends DialogFragment implements
             }
 
             authorDate.setText(styledAuthor);
-            ViewUtils.setGone(authorArea, false);
+            authorArea.setVisibility(View.VISIBLE);
         } else {
-            ViewUtils.setGone(authorArea, true);
+            authorArea.setVisibility(View.GONE);
         }
 
         if (isDifferentCommitter(commitAuthor, commitCommitter)) {
@@ -300,9 +299,9 @@ public class CommitDiffListFragment extends DialogFragment implements
             }
 
             committerDate.setText(styledCommitter);
-            ViewUtils.setGone(committerArea, false);
+            committerArea.setVisibility(View.VISIBLE);
         } else {
-            ViewUtils.setGone(committerArea, true);
+            committerArea.setVisibility(View.GONE);
         }
     }
 
@@ -336,8 +335,8 @@ public class CommitDiffListFragment extends DialogFragment implements
     }
 
     private void updateHeader(Commit commit) {
-        ViewUtils.setGone(progress, true);
-        ViewUtils.setGone(list, false);
+        progress.setVisibility(View.GONE);
+        list.setVisibility(View.VISIBLE);
 
         addCommitDetails(commit);
         addCommitParents(commit, getActivity().getLayoutInflater());

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitFileListAdapter.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitFileListAdapter.java
@@ -18,9 +18,9 @@ package com.github.pockethub.android.ui.commit;
 import android.content.res.Resources;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
+import android.view.View;
 
 import com.github.kevinsawicki.wishlist.MultiTypeAdapter;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.commit.FullCommitFile;
 import com.github.pockethub.android.ui.StyledText;
@@ -180,8 +180,7 @@ public class CommitFileListAdapter extends MultiTypeAdapter {
             int lastSlash = path.lastIndexOf('/');
             if (lastSlash != -1) {
                 setText(0, path.substring(lastSlash + 1));
-                ViewUtils.setGone(setText(1, path.substring(0, lastSlash + 1)),
-                        false);
+                setText(1, path.substring(0, lastSlash + 1)).setVisibility(View.VISIBLE);
             } else {
                 setText(0, path);
                 setGone(1, true);

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitFileViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitFileViewActivity.java
@@ -25,13 +25,13 @@ import android.util.Base64;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 
 import com.meisolsson.githubsdk.core.ServiceGenerator;
 import com.meisolsson.githubsdk.model.GitHubFile;
 import com.meisolsson.githubsdk.model.Repository;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.Intents.Builder;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.commit.CommitUtils;
@@ -236,8 +236,8 @@ public class CommitFileViewActivity extends BaseActivity implements
             ToastUtils.show(this, R.string.error_rendering_markdown);
         }
 
-        ViewUtils.setGone(loadingBar, true);
-        ViewUtils.setGone(codeView, false);
+        loadingBar.setVisibility(View.GONE);
+        codeView.setVisibility(View.VISIBLE);
 
         if (!TextUtils.isEmpty(rendered)) {
             renderedMarkdown = rendered.toString();
@@ -260,8 +260,8 @@ public class CommitFileViewActivity extends BaseActivity implements
     }
 
     private void loadMarkdown() {
-        ViewUtils.setGone(loadingBar, false);
-        ViewUtils.setGone(codeView, true);
+        loadingBar.setVisibility(View.VISIBLE);
+        codeView.setVisibility(View.GONE);
 
         String markdown = new String(Base64.decode(blob.content(), Base64.DEFAULT));
         Bundle args = new Bundle();
@@ -278,8 +278,8 @@ public class CommitFileViewActivity extends BaseActivity implements
                 .compose(this.bindToLifecycle())
                 .subscribe(response -> {
                     GitBlob gitBlob = response.body();
-                    ViewUtils.setGone(loadingBar, true);
-                    ViewUtils.setGone(codeView, false);
+                    loadingBar.setVisibility(View.GONE);
+                    codeView.setVisibility(View.VISIBLE);
 
                     editor.setSource(path, gitBlob);
                     blob = gitBlob;
@@ -293,15 +293,15 @@ public class CommitFileViewActivity extends BaseActivity implements
                             RENDER_MARKDOWN, true)) {
                         loadMarkdown();
                     } else {
-                        ViewUtils.setGone(loadingBar, true);
-                        ViewUtils.setGone(codeView, false);
+                        loadingBar.setVisibility(View.GONE);
+                        codeView.setVisibility(View.VISIBLE);
                         editor.setSource(path, gitBlob);
                     }
                 }, error -> {
                     Log.e(TAG, "Loading commit file contents failed", error);
 
-                    ViewUtils.setGone(loadingBar, true);
-                    ViewUtils.setGone(codeView, false);
+                    loadingBar.setVisibility(View.GONE);
+                    codeView.setVisibility(View.VISIBLE);
                     ToastUtils.show(this, error, R.string.error_file_load);
                 });
     }

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitListFragment.java
@@ -31,7 +31,6 @@ import com.meisolsson.githubsdk.core.ServiceGenerator;
 import com.meisolsson.githubsdk.model.Commit;
 import com.meisolsson.githubsdk.model.Repository;
 import com.github.kevinsawicki.wishlist.SingleTypeAdapter;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.ThrowableLoader;
 import com.github.pockethub.android.core.PageIterator;
@@ -263,7 +262,7 @@ public class CommitListFragment extends PagedItemFragment<Commit>
     @Override
     public ItemListFragment<Commit> setListShown(boolean shown,
             boolean animate) {
-        ViewUtils.setGone(branchFooterView, !shown);
+        branchFooterView.setVisibility(shown ? View.VISIBLE : View.GONE);
         return super.setListShown(shown, animate);
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFilesViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFilesViewActivity.java
@@ -20,11 +20,11 @@ import android.os.Bundle;
 import android.support.design.widget.TabLayout;
 import android.support.v7.app.ActionBar;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.ProgressBar;
 
 import com.meisolsson.githubsdk.model.Gist;
 import com.meisolsson.githubsdk.model.User;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.Intents.Builder;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.gist.FullGist;
@@ -111,9 +111,9 @@ public class GistFilesViewActivity extends PagerActivity {
         if (gist != null) {
             configurePager();
         } else {
-            ViewUtils.setGone(loadingBar, false);
-            ViewUtils.setGone(pager, true);
-            ViewUtils.setGone(tabs, true);
+            loadingBar.setVisibility(View.VISIBLE);
+            pager.setVisibility(View.GONE);
+            tabs.setVisibility(View.GONE);
             Single.create(new RefreshGistTask(this, gistId, imageGetter))
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
@@ -136,9 +136,9 @@ public class GistFilesViewActivity extends PagerActivity {
             actionBar.setSubtitle(R.string.anonymous);
         }
 
-        ViewUtils.setGone(loadingBar, true);
-        ViewUtils.setGone(pager, false);
-        ViewUtils.setGone(tabs, false);
+        loadingBar.setVisibility(View.GONE);
+        pager.setVisibility(View.VISIBLE);
+        tabs.setVisibility(View.VISIBLE);
 
         adapter = new GistFilesPagerAdapter(this, gist);
         pager.setAdapter(adapter);

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
@@ -38,7 +38,6 @@ import com.meisolsson.githubsdk.model.Gist;
 import com.meisolsson.githubsdk.model.GistFile;
 import com.meisolsson.githubsdk.model.GitHubComment;
 import com.meisolsson.githubsdk.model.User;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.accounts.AccountUtils;
 import com.github.pockethub.android.core.OnLoadListener;
@@ -240,8 +239,8 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
             description.setText(R.string.no_description_given);
         }
 
-        ViewUtils.setGone(progress, true);
-        ViewUtils.setGone(list, false);
+        progress.setVisibility(GONE);
+        list.setVisibility(VISIBLE);
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/FilterListAdapter.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/FilterListAdapter.java
@@ -16,13 +16,13 @@
 package com.github.pockethub.android.ui.issue;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.TextView;
 
 import com.meisolsson.githubsdk.model.Label;
 import com.meisolsson.githubsdk.model.Milestone;
 import com.meisolsson.githubsdk.model.User;
 import com.github.kevinsawicki.wishlist.SingleTypeAdapter;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.issue.IssueFilter;
 import com.github.pockethub.android.util.AvatarLoader;
@@ -73,14 +73,14 @@ public class FilterListAdapter extends SingleTypeAdapter<IssueFilter> {
         if (labels != null && !labels.isEmpty()) {
             TextView labelsText = textView(3);
             LabelDrawableSpan.setText(labelsText, labels);
-            ViewUtils.setGone(labelsText, false);
+            labelsText.setVisibility(View.VISIBLE);
         } else {
             setGone(3, true);
         }
 
         Milestone milestone = filter.getMilestone();
         if (milestone != null) {
-            ViewUtils.setGone(setText(4, milestone.title()), false);
+            setText(4, milestone.title()).setVisibility(View.VISIBLE);
         } else {
             setGone(4, true);
         }
@@ -88,7 +88,7 @@ public class FilterListAdapter extends SingleTypeAdapter<IssueFilter> {
         User assignee = filter.getAssignee();
         if (assignee != null) {
             avatars.bind(imageView(7), assignee);
-            ViewUtils.setGone(setText(6, assignee.login()), false);
+            setText(6, assignee.login()).setVisibility(View.VISIBLE);
         } else {
             setGone(5, true);
         }

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
@@ -45,7 +45,6 @@ import com.meisolsson.githubsdk.model.Milestone;
 import com.meisolsson.githubsdk.model.PullRequest;
 import com.meisolsson.githubsdk.model.Repository;
 import com.meisolsson.githubsdk.model.User;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.accounts.AccountUtils;
 import com.github.pockethub.android.core.issue.IssueStore;
@@ -335,7 +334,7 @@ public class IssueFragment extends DialogFragment {
 
         if (IssueUtils.isPullRequest(issue) && issue.pullRequest().commits() != null
                 && issue.pullRequest().commits() > 0) {
-            ViewUtils.setGone(commitsView, false);
+            commitsView.setVisibility(VISIBLE);
 
             TextView icon = (TextView) headerView.findViewById(R.id.tv_commit_icon);
             icon.setText(ICON_COMMIT);
@@ -344,7 +343,7 @@ public class IssueFragment extends DialogFragment {
                     issue.pullRequest().commits());
             ((TextView) headerView.findViewById(R.id.tv_pull_request_commits)).setText(commits);
         } else {
-            ViewUtils.setGone(commitsView, true);
+            commitsView.setVisibility(GONE);
         }
 
         boolean open = IssueState.open.equals(issue.state());
@@ -356,8 +355,10 @@ public class IssueFragment extends DialogFragment {
                 text.append(' ').append(closedAt);
             }
             stateText.setText(text);
+            stateText.setVisibility(VISIBLE);
+        } else {
+            stateText.setVisibility(GONE);
         }
-        ViewUtils.setGone(stateText, open);
 
         User assignee = issue.assignee();
         if (assignee != null) {
@@ -401,8 +402,8 @@ public class IssueFragment extends DialogFragment {
             milestoneArea.setVisibility(GONE);
         }
 
-        ViewUtils.setGone(progress, true);
-        ViewUtils.setGone(list, false);
+        progress.setVisibility(GONE);
+        list.setVisibility(VISIBLE);
         updateStateItem(issue);
     }
 
@@ -423,7 +424,7 @@ public class IssueFragment extends DialogFragment {
                     updateList(fullIssue.getIssue(), items);
                 }, e -> {
                     ToastUtils.show(getActivity(), e, R.string.error_issue_load);
-                    ViewUtils.setGone(progress, true);
+                    progress.setVisibility(GONE);
                 });
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueListAdapter.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueListAdapter.java
@@ -22,7 +22,6 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.github.kevinsawicki.wishlist.SingleTypeAdapter;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.ui.StyledText;
 import com.github.pockethub.android.util.AvatarLoader;
@@ -154,7 +153,7 @@ public abstract class IssueListAdapter<V> extends SingleTypeAdapter<V> {
                 if (!TextUtils.isEmpty(color)) {
                     View view = view(viewIndex + i);
                     view.setBackgroundColor(Color.parseColor('#' + color));
-                    ViewUtils.setGone(view, false);
+                    view.setVisibility(View.VISIBLE);
                 } else {
                     setGone(viewIndex + i, true);
                 }

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/MilestoneDialogFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/MilestoneDialogFragment.java
@@ -21,11 +21,11 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.ListView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.github.kevinsawicki.wishlist.SingleTypeAdapter;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.ui.BaseActivity;
 import com.github.pockethub.android.ui.SingleChoiceDialogFragment;
@@ -68,7 +68,7 @@ public class MilestoneDialogFragment extends SingleChoiceDialogFragment {
 
             String description = item.description();
             if (!TextUtils.isEmpty(description)) {
-                ViewUtils.setGone(setText(2, description), false);
+                setText(2, description).setVisibility(View.VISIBLE);
             } else {
                 setGone(2, true);
             }

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/SearchIssueListAdapter.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/SearchIssueListAdapter.java
@@ -18,7 +18,6 @@ package com.github.pockethub.android.ui.issue;
 import android.view.LayoutInflater;
 import android.view.View;
 
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.util.AvatarLoader;
 import com.meisolsson.githubsdk.model.Issue;
@@ -56,9 +55,9 @@ public class SearchIssueListAdapter extends IssueListAdapter<Issue> {
 
         numberPaintFlags = textView(view, 0).getPaintFlags();
         for (int i = 0; i < MAX_LABELS; i++) {
-            ViewUtils.setGone(view.findViewById(R.id.v_label0 + i), true);
+            view.findViewById(R.id.v_label0 + i).setVisibility(View.GONE);
         }
-        ViewUtils.setGone(view.findViewById(R.id.tv_pull_request_icon), true);
+        view.findViewById(R.id.tv_pull_request_icon).setVisibility(View.GONE);
         return view;
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/ref/BranchFileViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/ref/BranchFileViewActivity.java
@@ -25,12 +25,12 @@ import android.util.Base64;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 
 import com.meisolsson.githubsdk.core.ServiceGenerator;
 import com.meisolsson.githubsdk.model.Repository;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.Intents.Builder;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.commit.CommitUtils;
@@ -233,8 +233,8 @@ public class BranchFileViewActivity extends BaseActivity implements
             ToastUtils.show(this, R.string.error_rendering_markdown);
         }
 
-        ViewUtils.setGone(loadingBar, true);
-        ViewUtils.setGone(codeView, false);
+        loadingBar.setVisibility(View.GONE);
+        codeView.setVisibility(View.VISIBLE);
 
         if (!TextUtils.isEmpty(rendered)) {
             renderedMarkdown = rendered.toString();
@@ -256,8 +256,8 @@ public class BranchFileViewActivity extends BaseActivity implements
     }
 
     private void loadMarkdown() {
-        ViewUtils.setGone(loadingBar, false);
-        ViewUtils.setGone(codeView, true);
+        loadingBar.setVisibility(View.VISIBLE);
+        codeView.setVisibility(View.GONE);
 
         String markdown = new String(Base64.decode(blob.content(), Base64.DEFAULT));
         Bundle args = new Bundle();
@@ -267,8 +267,8 @@ public class BranchFileViewActivity extends BaseActivity implements
     }
 
     private void loadContent() {
-        ViewUtils.setGone(loadingBar, false);
-        ViewUtils.setGone(codeView, true);
+        loadingBar.setVisibility(View.VISIBLE);
+        codeView.setVisibility(View.GONE);
 
         ServiceGenerator.createService(this, GitService.class)
                 .getGitBlob(repo.owner().login(), repo.name(), sha)
@@ -287,16 +287,16 @@ public class BranchFileViewActivity extends BaseActivity implements
                             RENDER_MARKDOWN, true)) {
                         loadMarkdown();
                     } else {
-                        ViewUtils.setGone(loadingBar, true);
-                        ViewUtils.setGone(codeView, false);
+                        loadingBar.setVisibility(View.GONE);
+                        codeView.setVisibility(View.VISIBLE);
 
                         editor.setMarkdown(false).setSource(file, blob);
                     }
                 }, e -> {
                     Log.d(TAG, "Loading file contents failed", e);
 
-                    ViewUtils.setGone(loadingBar, true);
-                    ViewUtils.setGone(codeView, false);
+                    loadingBar.setVisibility(View.GONE);
+                    codeView.setVisibility(View.VISIBLE);
                     ToastUtils.show(this, e, R.string.error_file_load);
                 });
     }

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryListAdapter.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryListAdapter.java
@@ -17,9 +17,9 @@ package com.github.pockethub.android.ui.repo;
 
 import android.text.TextUtils;
 import android.view.LayoutInflater;
+import android.view.View;
 
 import com.github.kevinsawicki.wishlist.SingleTypeAdapter;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 
 import static com.github.pockethub.android.ui.view.OcticonTextView.ICON_FORK;
 import static com.github.pockethub.android.ui.view.OcticonTextView.ICON_MIRROR_PRIVATE;
@@ -80,13 +80,13 @@ public abstract class RepositoryListAdapter<V> extends SingleTypeAdapter<V> {
         }
 
         if (!TextUtils.isEmpty(description)) {
-            ViewUtils.setGone(setText(1, description), false);
+            setText(1, description).setVisibility(View.VISIBLE);
         } else {
             setGone(1, true);
         }
 
         if (!TextUtils.isEmpty(language)) {
-            ViewUtils.setGone(setText(2, language), false);
+            setText(2, language).setVisibility(View.VISIBLE);
         } else {
             setGone(2, true);
         }

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.java
@@ -22,13 +22,13 @@ import android.support.v7.app.ActionBar;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.ProgressBar;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.meisolsson.githubsdk.core.ServiceGenerator;
 import com.meisolsson.githubsdk.model.Repository;
 import com.meisolsson.githubsdk.model.User;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.Intents.Builder;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.repo.RepositoryUtils;
@@ -107,7 +107,7 @@ public class RepositoryViewActivity extends TabPagerActivity<RepositoryPagerAdap
             checkReadme();
         } else {
             avatars.bind(getSupportActionBar(), owner);
-            ViewUtils.setGone(loadingBar, false);
+            loadingBar.setVisibility(View.VISIBLE);
             setGone(true);
             ServiceGenerator.createService(this, RepositoryService.class)
                     .getRepository(repository.owner().login(), repository.name())
@@ -119,7 +119,7 @@ public class RepositoryViewActivity extends TabPagerActivity<RepositoryPagerAdap
                         checkReadme();
                     }, e -> {
                         ToastUtils.show(this, R.string.error_repo_load);
-                        ViewUtils.setGone(loadingBar, true);
+                        loadingBar.setVisibility(View.GONE);
                     });
         }
     }
@@ -165,7 +165,7 @@ public class RepositoryViewActivity extends TabPagerActivity<RepositoryPagerAdap
     private void configurePager() {
         avatars.bind(getSupportActionBar(), repository.owner());
         configureTabPager();
-        ViewUtils.setGone(loadingBar, true);
+        loadingBar.setVisibility(View.GONE);
         setGone(false);
         checkStarredRepositoryStatus();
     }

--- a/app/src/main/java/com/github/pockethub/android/ui/search/SearchActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/search/SearchActivity.java
@@ -25,9 +25,9 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.widget.SearchView;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.ProgressBar;
 
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.ui.MainActivity;
 import com.github.pockethub.android.ui.TabPagerActivity;
@@ -152,7 +152,7 @@ public class SearchActivity extends TabPagerActivity<SearchPagerAdapter> {
 
     private void configurePager() {
         configureTabPager();
-        ViewUtils.setGone(loadingBar, true);
+        loadingBar.setVisibility(View.GONE);
         setGone(false);
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/user/IconAndViewTextManager.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/user/IconAndViewTextManager.java
@@ -17,6 +17,7 @@
 package com.github.pockethub.android.ui.user;
 
 import android.text.TextUtils;
+import android.view.View;
 
 import com.meisolsson.githubsdk.model.GitHubComment;
 import com.meisolsson.githubsdk.model.GitHubEvent;
@@ -27,7 +28,6 @@ import com.meisolsson.githubsdk.model.Repository;
 import com.meisolsson.githubsdk.model.ReviewComment;
 import com.meisolsson.githubsdk.model.Team;
 import com.meisolsson.githubsdk.model.User;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.core.issue.IssueUtils;
 import com.github.pockethub.android.ui.StyledText;
 import com.github.pockethub.android.util.TimeUtils;
@@ -446,7 +446,7 @@ public class IconAndViewTextManager {
         String icon = setIconAndFormatStyledText(event, main, details);
 
         if (icon != null) {
-            ViewUtils.setGone(newsListAdapter.setTextAgent(3, icon), false);
+            newsListAdapter.setTextAgent(3, icon).setVisibility(View.VISIBLE);
         } else {
             newsListAdapter.setGoneAgent(3, true);
         }
@@ -454,7 +454,7 @@ public class IconAndViewTextManager {
         newsListAdapter.setTextAgent(1, main);
 
         if (!TextUtils.isEmpty(details)) {
-            ViewUtils.setGone(newsListAdapter.setTextAgent(2, details), false);
+            newsListAdapter.setTextAgent(2, details).setVisibility(View.VISIBLE);
         } else {
             newsListAdapter.setGoneAgent(2, true);
         }

--- a/app/src/main/java/com/github/pockethub/android/ui/user/UserViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/user/UserViewActivity.java
@@ -21,11 +21,11 @@ import android.support.v7.app.ActionBar;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.ProgressBar;
 
 import com.meisolsson.githubsdk.core.ServiceGenerator;
 import com.meisolsson.githubsdk.model.User;
-import com.github.kevinsawicki.wishlist.ViewUtils;
 import com.github.pockethub.android.Intents.Builder;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.accounts.AccountUtils;
@@ -92,7 +92,7 @@ public class UserViewActivity extends TabPagerActivity<UserPagerAdapter>
         if (!TextUtils.isEmpty(user.avatarUrl())) {
             configurePager();
         } else {
-            ViewUtils.setGone(loadingBar, false);
+            loadingBar.setVisibility(View.VISIBLE);
             setGone(true);
             ServiceGenerator.createService(this, UserService.class)
                     .getUser(user.login())
@@ -104,7 +104,7 @@ public class UserViewActivity extends TabPagerActivity<UserPagerAdapter>
                         configurePager();
                     }, e -> {
                         ToastUtils.show(this, R.string.error_person_load);
-                        ViewUtils.setGone(loadingBar, true);
+                        loadingBar.setVisibility(View.GONE);
                     });
         }
     }
@@ -147,7 +147,7 @@ public class UserViewActivity extends TabPagerActivity<UserPagerAdapter>
     private void configurePager() {
         avatars.bind(getSupportActionBar(), user);
         configureTabPager();
-        ViewUtils.setGone(loadingBar, true);
+        loadingBar.setVisibility(View.GONE);
         setGone(false);
         checkFollowingUserStatus();
     }


### PR DESCRIPTION
Closes #1073.

Note that the problems described in #1073 are still evident, as `setGone(…)` methods are described in the source of the app itself and where Wishlist is depending on `ViewUtils.setGone(…)` internally, i.e. [TabPagerFragment#setGone(…)](https://github.com/pockethub/PocketHub/compare/master...veyndan:viewutils?expand=1#diff-278df97d2517489f683facf5b4910857L100), [TabPagerActivity#setGone(…)](https://github.com/pockethub/PocketHub/compare/master...veyndan:viewutils?expand=1#diff-15ae27ba4465afcc486e24b5f19d2186L98), [NewsListAdapter#setGoneAgent(…)](https://github.com/pockethub/PocketHub/compare/master...veyndan:viewutils?expand=1#diff-3f78703dd15ef5bbac3b5f9f1e37927bL451), and everywhere the Wishlist TypeAdapter is used.

I didn't address the above issues in this PR as I didn't feel that it is within the scope of this PR or the GitHub issue that it is closing.