### PR TITLE
Make loading view to center in the page.

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.java
@@ -94,7 +94,7 @@ public class RepositoryViewActivity extends TabPagerActivity<RepositoryPagerAdap
 
         repository = getParcelableExtra(EXTRA_REPOSITORY);
 
-        loadingBar = finder.find(R.id.progress_bar);
+        loadingBar = finder.find(R.id.pb_loading);
 
         User owner = repository.owner();
 
@@ -148,6 +148,7 @@ public class RepositoryViewActivity extends TabPagerActivity<RepositoryPagerAdap
     }
 
     private void checkReadme() {
+        loadingBar.setVisibility(View.VISIBLE);
         ServiceGenerator.createService(this, RepositoryContentService.class)
                 .hasReadme(repository.owner().login(), repository.name())
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/res/layout/pager_with_tabs.xml
+++ b/app/src/main/res/layout/pager_with_tabs.xml
@@ -52,10 +52,4 @@
         app:layout_behavior="com.github.pockethub.android.ui.PatchedScrollingViewBehavior"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-
-    <ProgressBar
-        android:id="@+id/progress_bar"
-        style="@style/ListSpinner"
-        android:layout_centerInParent="true"
-        android:visibility="gone" />
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/tabbed_progress_pager.xml
+++ b/app/src/main/res/layout/tabbed_progress_pager.xml
@@ -14,19 +14,18 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"
     android:orientation="vertical" >
 
-    <ProgressBar
-        android:id="@+id/pb_loading"
-        style="@style/Spinner"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:visibility="gone" />
-
     <include layout="@layout/pager_with_tabs" />
 
-</LinearLayout>
+    <ProgressBar
+        android:id="@+id/pb_loading"
+        style="@style/ListSpinner"
+        android:visibility="gone"
+        android:layout_gravity="center"/>
+
+</FrameLayout>


### PR DESCRIPTION
Repruduce steps:
1. Click one issue of "News" tab in Home page.
2. Click home/back button on the toolbar in the opened issue page.
3. Will see a strange loading view on the toolbar. See screenshot "Before".

Screenshot "After" represents the UI change after this pr.

**Before**
![device-2017-04-03-100714](https://cloud.githubusercontent.com/assets/3632276/24592796/06614544-184f-11e7-8660-747d2ce8dfa6.png)

**After**
![device-2017-04-03-093952](https://cloud.githubusercontent.com/assets/3632276/24592873/b8e02546-184f-11e7-991c-5ec7b833a51f.png)

