### PR TITLE
Make FullIssue and FullGist POJOs

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/core/gist/FullGist.java
+++ b/app/src/main/java/com/github/pockethub/android/core/gist/FullGist.java
@@ -18,20 +18,16 @@ package com.github.pockethub.android.core.gist;
 import com.meisolsson.githubsdk.model.Gist;
 import com.meisolsson.githubsdk.model.GitHubComment;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 
 /**
  * Gist model with comments and starred status
  */
-public class FullGist extends ArrayList<GitHubComment> implements Serializable {
-
-    private static final long serialVersionUID = -5966699489498437000L;
+public class FullGist {
 
     private final Gist gist;
-
     private final boolean starred;
+    private final List<GitHubComment> comments;
 
     /**
      * Create gist with comments
@@ -40,20 +36,17 @@ public class FullGist extends ArrayList<GitHubComment> implements Serializable {
      * @param starred
      * @param comments
      */
-    public FullGist(final Gist gist, final boolean starred,
-            final Collection<GitHubComment> comments) {
-        super(comments);
-
-        this.starred = starred;
+    public FullGist(final Gist gist, final boolean starred, final List<GitHubComment> comments) {
         this.gist = gist;
+        this.starred = starred;
+        this.comments = comments;
     }
 
     /**
-     * Create empty gist
+     * @return gist
      */
-    public FullGist() {
-        this.gist = null;
-        this.starred = false;
+    public Gist getGist() {
+        return gist;
     }
 
     /**
@@ -64,9 +57,9 @@ public class FullGist extends ArrayList<GitHubComment> implements Serializable {
     }
 
     /**
-     * @return gist
+     * @return comments
      */
-    public Gist getGist() {
-        return gist;
+    public List<GitHubComment> getComments() {
+        return comments;
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/core/issue/FullIssue.java
+++ b/app/src/main/java/com/github/pockethub/android/core/issue/FullIssue.java
@@ -15,25 +15,20 @@
  */
 package com.github.pockethub.android.core.issue;
 
-
 import com.meisolsson.githubsdk.model.GitHubComment;
 import com.meisolsson.githubsdk.model.Issue;
 import com.meisolsson.githubsdk.model.IssueEvent;
 
-import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collection;
 
 /**
  * Issue model with comments
  */
-public class FullIssue extends ArrayList<GitHubComment> implements Serializable {
-
-    private static final long serialVersionUID = 4586476132467323827L;
+public class FullIssue {
 
     private final Issue issue;
-
-    private Collection<IssueEvent> events;
+    private final Collection<GitHubComment> comments;
+    private final Collection<IssueEvent> events;
 
     /**
      * Create wrapper for issue, comments and events
@@ -43,17 +38,9 @@ public class FullIssue extends ArrayList<GitHubComment> implements Serializable 
      * @param events
      */
     public FullIssue(final Issue issue, final Collection<GitHubComment> comments, final Collection<IssueEvent> events) {
-        super(comments);
-
-        this.events = events;
         this.issue = issue;
-    }
-
-    /**
-     * Create empty wrapper
-     */
-    public FullIssue() {
-        this.issue = null;
+        this.comments = comments;
+        this.events = events;
     }
 
     /**
@@ -63,6 +50,12 @@ public class FullIssue extends ArrayList<GitHubComment> implements Serializable 
         return issue;
     }
 
+    /**
+     * @return comments
+     */
+    public Collection<GitHubComment> getComments() {
+        return comments;
+    }
 
     /**
      * @return events
@@ -70,5 +63,4 @@ public class FullIssue extends ArrayList<GitHubComment> implements Serializable 
     public Collection<IssueEvent> getEvents() {
         return events;
     }
-
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
@@ -415,8 +415,8 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                     starred = fullGist.isStarred();
                     loadFinished = true;
                     gist = fullGist.getGist();
-                    comments = fullGist;
-                    updateList(fullGist.getGist(), fullGist);
+                    comments = fullGist.getComments();
+                    updateList(fullGist.getGist(), fullGist.getComments());
                 }, e -> ToastUtils.show(getActivity(), e, R.string.error_gist_load));
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
@@ -417,7 +417,7 @@ public class IssueFragment extends DialogFragment {
                     issue = fullIssue.getIssue();
                     items = new ArrayList<>();
                     items.addAll(fullIssue.getEvents());
-                    items.addAll(fullIssue);
+                    items.addAll(fullIssue.getComments());
                     updateList(fullIssue.getIssue(), items);
                 }, e -> {
                     ToastUtils.show(getActivity(), e, R.string.error_issue_load);


### PR DESCRIPTION
I feel that `comments = fullGist.getComments()` is more readable than `comments = fullGist` for example, hence this PR.