### PR TITLE
Show the progress dialog automatically when subscribing to the ProgressObserverAdapter

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/rx/ProgressObserverAdapter.java
+++ b/app/src/main/java/com/github/pockethub/android/rx/ProgressObserverAdapter.java
@@ -49,8 +49,10 @@ public class ProgressObserverAdapter<T> implements Observer<T>, SingleObserver<T
         dismissProgress();
     }
 
+    @CallSuper
     @Override
     public void onSubscribe(final Disposable d) {
+        showProgressIndeterminate(message);
     }
 
     @Override
@@ -94,10 +96,5 @@ public class ProgressObserverAdapter<T> implements Observer<T>, SingleObserver<T
      */
     protected void showProgressIndeterminate(@StringRes final int resId) {
         showProgressIndeterminate(context.getString(resId));
-    }
-
-    public ProgressObserverAdapter<T> start() {
-        showProgressIndeterminate(message);
-        return this;
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CreateCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CreateCommentActivity.java
@@ -135,7 +135,7 @@ public class CreateCommentActivity extends
                         super.onError(e);
                         ToastUtils.show(CreateCommentActivity.this, e.getMessage());
                     }
-                }.start());
+                });
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/CreateGistActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/CreateGistActivity.java
@@ -213,6 +213,6 @@ public class CreateGistActivity extends BaseActivity {
                         Log.d(TAG, "Exception creating Gist", e);
                         ToastUtils.show(CreateGistActivity.this, e.getMessage());
                     }
-                }.start());
+                });
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/EditCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/EditCommentActivity.java
@@ -115,7 +115,7 @@ public class EditCommentActivity extends
                         Log.d(TAG, "Exception editing comment on gist", e);
                         ToastUtils.show(EditCommentActivity.this, e.getMessage());
                     }
-                }.start());
+                });
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
@@ -467,7 +467,7 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                             Log.d(TAG, "Exception deleting comment on gist", e);
                             ToastUtils.show((Activity) getContext(), e.getMessage());
                         }
-                    }.start());
+                    });
             break;
         }
     }

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.java
@@ -188,7 +188,7 @@ public class GistsViewActivity extends PagerActivity implements
                             Log.d(TAG, "Exception deleting Gist", e);
                             ToastUtils.show(GistsViewActivity.this, e.getMessage());
                         }
-                    }.start());
+                    });
             return;
         }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/AssigneeDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/AssigneeDialog.java
@@ -89,7 +89,7 @@ public class AssigneeDialog extends BaseProgressDialog {
                     Log.d(TAG, "Exception loading collaborators", error);
                     ToastUtils.show(activity, error, R.string.error_collaborators_load);
                 }
-            }.start());
+            });
     }
 
     private Observable<Page<User>> getPageAndNext(int i) {

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditCommentActivity.java
@@ -127,7 +127,7 @@ public class EditCommentActivity extends
                         Log.d(TAG, "Exception editing comment on issue", e);
                         ToastUtils.show(EditCommentActivity.this, e.getMessage());
                     }
-                }.start());
+                });
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditIssueActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditIssueActivity.java
@@ -510,7 +510,7 @@ public class EditIssueActivity extends BaseActivity {
                                 Log.e(TAG, "Exception creating issue", e);
                                 ToastUtils.show(EditIssueActivity.this, e.getMessage());
                             }
-                        }.start());
+                        });
                 return true;
             default:
                 return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditStateTask.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditStateTask.java
@@ -108,7 +108,6 @@ public class EditStateTask implements SingleOnSubscribe<Issue> {
         int message = close ? R.string.closing_issue : R.string.reopening_issue;
         this.close = close;
         observer.setContent(message);
-        observer.start();
 
         Single.create(this)
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
@@ -525,7 +525,7 @@ public class IssueFragment extends DialogFragment {
                             Log.d(TAG, "Exception deleting comment on issue", e);
                             ToastUtils.show(getActivity(), e.getMessage());
                         }
-                    }.start());
+                    });
             break;
         }
     }

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/LabelsDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/LabelsDialog.java
@@ -91,7 +91,7 @@ public class LabelsDialog extends BaseProgressDialog {
                     Log.e(TAG, "Exception loading labels", error);
                     ToastUtils.show(activity, error, R.string.error_labels_load);
                 }
-            }.start());
+            });
     }
 
     private Observable<Page<Label>> getPageAndNext(int i) {

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/MilestoneDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/MilestoneDialog.java
@@ -96,7 +96,7 @@ public class MilestoneDialog extends BaseProgressDialog {
                     Log.e(TAG, "Exception loading milestones", error);
                     ToastUtils.show(activity, error, R.string.error_milestones_load);
                 }
-            }.start());
+            });
     }
 
     private Observable<Page<Milestone>> getPageAndNext(int i) {

--- a/app/src/main/java/com/github/pockethub/android/ui/ref/RefDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/ref/RefDialog.java
@@ -89,7 +89,7 @@ public class RefDialog {
                     Log.d(TAG, "Exception loading references", e);
                     ToastUtils.show(activity, e, R.string.error_refs_load);
                 }
-            }.start());
+            });
     }
 
     private Observable<Page<GitReference>> getPageAndNext(int i) {


### PR DESCRIPTION
By automatically calling `showProgressIndeterminate(…)` once the `ProgressObserverAdapter` is subscribed to, we no longer have to remember to call `.start()` on it. For example it was forgotten [here](https://github.com/pockethub/PocketHub/blob/7fe47c12af947fead174109a0f9b852361757d43/app/src/main/java/com/github/pockethub/android/ui/search/SearchRepositoryListFragment.java#L121).