### PR TITLE
Removing blockingGet() calls

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/core/code/RefreshTreeTask.java
+++ b/app/src/main/java/com/github/pockethub/android/core/code/RefreshTreeTask.java
@@ -20,6 +20,7 @@ import android.text.TextUtils;
 
 import com.github.pockethub.android.core.ref.RefUtils;
 import com.meisolsson.githubsdk.core.ServiceGenerator;
+import com.meisolsson.githubsdk.model.Commit;
 import com.meisolsson.githubsdk.model.Repository;
 import com.meisolsson.githubsdk.model.git.GitCommit;
 import com.meisolsson.githubsdk.model.git.GitReference;
@@ -28,14 +29,18 @@ import com.meisolsson.githubsdk.service.git.GitService;
 import com.meisolsson.githubsdk.service.repositories.RepositoryService;
 
 import java.io.IOException;
+import java.sql.Ref;
 
+import io.reactivex.Observable;
+import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
 import io.reactivex.SingleOnSubscribe;
+import retrofit2.Response;
 
 /**
  * Task to load the tree for a repo's default branch
  */
-public class RefreshTreeTask implements SingleOnSubscribe<FullTree> {
+public class RefreshTreeTask {
 
     private static final String TAG = "RefreshTreeTask";
 
@@ -63,50 +68,83 @@ public class RefreshTreeTask implements SingleOnSubscribe<FullTree> {
                 && !TextUtils.isEmpty(ref.object().sha());
     }
 
-    @Override
-    public void subscribe(SingleEmitter<FullTree> emitter) throws Exception {
-        GitReference ref = reference;
+    private Single<GitReference> getValidRef(GitService service, GitReference ref, String branch) {
+        if (!isValidRef(ref)) {
+            return service.getGitReference(repo.owner().login(), repo.name(), branch)
+                    .map(response -> {
+                        if (response.isSuccessful()) {
+                            GitReference fetchedRef = response.body();
+                            if (isValidRef(fetchedRef)) {
+                                return fetchedRef;
+                            } else {
+                                throw new IOException("Reference does not have associated commit SHA-1");
+                            }
+                        } else {
+                            throw new IOException("Request for Git Reference was unsuccessful");
+                        }
+                    });
+        }
+
+        return Single.just(ref);
+    }
+
+    private Single<String> getBranch(GitReference ref) {
         String branch = RefUtils.getPath(ref);
         if (branch == null) {
             branch = repo.defaultBranch();
             if (TextUtils.isEmpty(branch)) {
-                branch = ServiceGenerator.createService(context, RepositoryService.class)
+                return ServiceGenerator
+                        .createService(context, RepositoryService.class)
                         .getRepository(repo.owner().login(), repo.name())
-                        .blockingGet()
-                        .body()
-                        .defaultBranch();
-                if (TextUtils.isEmpty(branch)) {
-                    emitter.onError(new IOException(
-                            "Repository does not have master branch"));
-                }
+                        .map(response -> response.body().defaultBranch());
             }
         }
 
+        return Single.just(branch);
+    }
+
+    public Single<FullTree> refresh() {
         GitService gitService = ServiceGenerator.createService(context, GitService.class);
 
-        if (!isValidRef(ref)) {
-            branch = branch.replace("heads/", "");
-            ref = gitService.getGitReference(repo.owner().login(), repo.name(), branch)
-                    .blockingGet().body();
-            if (!isValidRef(ref)) {
-                emitter.onError(new IOException("Reference does not have associated commit SHA-1"));
-                return;
-            }
+        return getBranch(reference)
+                .map(branch -> branch.replace("heads/", ""))
+                .flatMap(branch -> getValidRef(gitService, reference, branch))
+                .flatMap(reference ->
+                        gitService.getGitCommit(repo.owner().login(), repo.name(),
+                                reference.object().sha())
+                                .map(Response::body)
+                                .zipWith(Single.just(reference), RefreshTreeModel::new))
+                .flatMap(model ->
+                        gitService.getGitTreeRecursive(repo.owner().login(),
+                                repo.name(), model.getCommit().tree().sha())
+                                .map(Response::body)
+                                .zipWith(Single.just(model.ref), FullTree::new));
+    }
+
+    private class RefreshTreeModel {
+        private GitReference ref;
+        private GitCommit commit;
+
+        public RefreshTreeModel(GitCommit commit, GitReference ref) {
+            this.commit = commit;
+            this.ref = ref;
         }
 
-        GitCommit commit = gitService
-                .getGitCommit(repo.owner().login(), repo.name(), ref.object().sha())
-                .blockingGet()
-                .body();
-        if (commit == null || commit.tree() == null || TextUtils.isEmpty(commit.tree().sha())) {
-            emitter.onError(new IOException("Commit does not have associated tree SHA-1"));
-            return;
+        public GitReference getRef() {
+            return ref;
         }
 
-        GitTree tree = gitService
-                .getGitTreeRecursive(repo.owner().login(), repo.name(), commit.tree().sha())
-                .blockingGet()
-                .body();
-        emitter.onSuccess(new FullTree(tree, ref));
+        public void setRef(GitReference ref) {
+            this.ref = ref;
+        }
+
+        public GitCommit getCommit() {
+            return commit;
+        }
+
+        public void setCommit(GitCommit commit) {
+            this.commit = commit;
+        }
+
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/core/commit/CommitStore.java
+++ b/app/src/main/java/com/github/pockethub/android/core/commit/CommitStore.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.reactivex.Single;
+
 
 /**
  * Store of commits
@@ -83,19 +85,15 @@ public class CommitStore extends ItemStore {
     }
 
     /**
-     * Refresh commit
+     * Refresh commit.
      *
-     * @param repo
-     * @param id
+     * @param repo The repo which the commit is in
+     * @param id The id of the commit
      * @return refreshed commit
-     * @throws IOException
      */
-    public Commit refreshCommit(final Repository repo, final String id) throws IOException {
-        Commit commit = ServiceGenerator.createService(context, RepositoryCommitService.class)
+    public Single<Commit> refreshCommit(final Repository repo, final String id) {
+        return ServiceGenerator.createService(context, RepositoryCommitService.class)
                 .getCommit(repo.owner().login(), repo.name(), id)
-                .blockingGet()
-                .body();
-
-        return addCommit(repo, commit);
+                .map(response -> addCommit(repo, response.body()));
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/core/commit/RefreshCommitTask.java
+++ b/app/src/main/java/com/github/pockethub/android/core/commit/RefreshCommitTask.java
@@ -19,25 +19,20 @@ import android.app.Activity;
 import android.content.Context;
 
 import com.github.pockethub.android.util.HttpImageGetter;
+import com.github.pockethub.android.util.RxPageUtil;
 import com.meisolsson.githubsdk.core.ServiceGenerator;
-import com.meisolsson.githubsdk.model.Commit;
 import com.meisolsson.githubsdk.model.Repository;
-import com.meisolsson.githubsdk.model.git.GitComment;
-import com.meisolsson.githubsdk.model.git.GitCommit;
 import com.meisolsson.githubsdk.service.repositories.RepositoryCommentService;
 import com.google.inject.Inject;
 
-import java.io.IOException;
-import java.util.List;
-
-import io.reactivex.SingleEmitter;
-import io.reactivex.SingleOnSubscribe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
 import roboguice.RoboGuice;
 
 /**
  * Task to load a commit by SHA-1 id
  */
-public class RefreshCommitTask implements SingleOnSubscribe<FullCommit> {
+public class RefreshCommitTask {
 
     private final Context context;
 
@@ -65,27 +60,25 @@ public class RefreshCommitTask implements SingleOnSubscribe<FullCommit> {
         RoboGuice.injectMembers(activity, this);
     }
 
-    @Override
-    public void subscribe(SingleEmitter<FullCommit> emitter) throws Exception {
-        try {
-            Commit commit = store.refreshCommit(repository, id);
-            GitCommit rawCommit = commit.commit();
-            if (rawCommit != null && rawCommit.commentCount() > 0) {
-                List<GitComment> comments = ServiceGenerator.createService(context, RepositoryCommentService.class)
-                        .getCommitComments(repository.owner().login(), repository.name(), commit.sha(), 1)
-                        .blockingGet()
-                        .body()
-                        .items();
+    /**
+     * Fetches a commit with it's comments.
+     *
+     * @return Single for a FullCommit
+     */
+    public Single<FullCommit> refresh() {
+        RepositoryCommentService commentService =
+                ServiceGenerator.createService(context, RepositoryCommentService.class);
 
-                for (GitComment comment : comments) {
-                    imageGetter.encode(comment, comment.bodyHtml());
-                }
-                emitter.onSuccess(new FullCommit(commit, comments));
-            } else {
-                emitter.onSuccess(new FullCommit(commit));
-            }
-        }catch (IOException e){
-            emitter.onError(e);
-        }
+        return store.refreshCommit(repository, id)
+                .flatMap(commit -> RxPageUtil.getAllPages((page) ->
+                        commentService.getCommitComments(repository.owner().login(),
+                                repository.name(), commit.sha(), page), 1)
+                        .flatMap(page -> Observable.fromIterable(page.items()))
+                        .map(comment -> {
+                            imageGetter.encode(comment, comment.bodyHtml());
+                            return comment;
+                        })
+                        .toList()
+                        .map(comments -> new FullCommit(commit, comments)));
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/core/gist/GistStore.java
+++ b/app/src/main/java/com/github/pockethub/android/core/gist/GistStore.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.TreeMap;
 
+import io.reactivex.Single;
+
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 
 /**
@@ -95,36 +97,30 @@ public class GistStore extends ItemStore {
     }
 
     /**
-     * Refresh gist
+     * Refresh gist.
      *
-     * @param id
+     * @param id The id of the Gist to update
      * @return refreshed gist
-     * @throws IOException
      */
-    public Gist refreshGist(String id) throws IOException {
-        return ServiceGenerator.createService(context, GistService.class)
-                .getGist(id)
-                .blockingGet()
-                .body();
+    public Single<Gist> refreshGist(String id) {
+        return ServiceGenerator.createService(context, GistService.class).getGist(id)
+                .map(response -> addGist(response.body()));
     }
 
     /**
-     * Edit gist
+     * Edit gist.
      *
-     * @param gist
+     * @param gist The Gist to edit
      * @return edited gist
-     * @throws IOException
      */
-    public Gist editGist(Gist gist) throws IOException {
+    public Single<Gist> editGist(Gist gist) {
         CreateGist edit = CreateGist.builder()
                 .files(gist.files())
                 .description(gist.description())
                 .isPublic(gist.isPublic())
                 .build();
 
-        return ServiceGenerator.createService(context, GistService.class)
-                .editGist(edit)
-                .blockingGet()
-                .body();
+        return ServiceGenerator.createService(context, GistService.class).editGist(edit)
+                .map(response -> addGist(response.body()));
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/core/issue/RefreshIssueTask.java
+++ b/app/src/main/java/com/github/pockethub/android/core/issue/RefreshIssueTask.java
@@ -17,7 +17,9 @@ package com.github.pockethub.android.core.issue;
 
 import android.content.Context;
 
+import com.github.pockethub.android.core.PageIterator;
 import com.github.pockethub.android.util.HttpImageGetter;
+import com.github.pockethub.android.util.RxPageUtil;
 import com.meisolsson.githubsdk.core.ServiceGenerator;
 import com.meisolsson.githubsdk.model.GitHubComment;
 import com.meisolsson.githubsdk.model.Issue;
@@ -30,19 +32,20 @@ import com.meisolsson.githubsdk.service.issues.IssueEventService;
 import com.google.inject.Inject;
 import com.meisolsson.githubsdk.service.pull_request.PullRequestService;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import io.reactivex.SingleEmitter;
-import io.reactivex.SingleOnSubscribe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+import retrofit2.Response;
 import roboguice.RoboGuice;
 
 /**
  * Task to load and store an {@link Issue}
  */
-public class RefreshIssueTask implements SingleOnSubscribe<FullIssue> {
+public class RefreshIssueTask {
 
     private static final String TAG = "RefreshIssueTask";
 
@@ -61,13 +64,14 @@ public class RefreshIssueTask implements SingleOnSubscribe<FullIssue> {
 
 
     /**
-     * Create task to refresh given issue
+     * Create task to refresh given issue.
      *
-     * @param repo
-     * @param issueNumber
-     * @param bodyImageGetter
+     * @param repo The repository to refresh issue from
+     * @param issueNumber The issue's number
+     * @param bodyImageGetter {@link HttpImageGetter} to fetch images for the bodies
      */
-    public RefreshIssueTask(Context context, Repository repo, int issueNumber, HttpImageGetter bodyImageGetter, HttpImageGetter commentImageGetter) {
+    public RefreshIssueTask(Context context, Repository repo, int issueNumber,
+                            HttpImageGetter bodyImageGetter, HttpImageGetter commentImageGetter) {
         this.repo = repo;
         this.issueNumber = issueNumber;
         this.bodyImageGetter = bodyImageGetter;
@@ -76,80 +80,76 @@ public class RefreshIssueTask implements SingleOnSubscribe<FullIssue> {
         RoboGuice.getInjector(context).injectMembers(this);
     }
 
-    @Override
-    public void subscribe(SingleEmitter<FullIssue> emitter) throws Exception {
-        try {
-            Issue issue = store.refreshIssue(repo, issueNumber);
+    /**
+     * Fetches an issue and it's comments, event and pull request if applicable.
+     *
+     * @return {@link Single} for a {@link FullIssue}
+     */
+    public Single<FullIssue> refresh() {
+        return store.refreshIssue(repo, issueNumber)
+                .flatMap(issue -> {
+                    if (issue.pullRequest() != null) {
+                        return getPullRequest(repo.owner().login(), repo.name(), issueNumber)
+                                .map(pullRequest -> issue.toBuilder()
+                                        .pullRequest(pullRequest)
+                                        .build());
+                    }
 
-            if (issue.pullRequest() != null) {
-                PullRequest pull = getPullRequest(repo.owner().login(), repo.name(), issueNumber);
-                issue = issue.toBuilder()
-                        .pullRequest(pull)
-                        .build();
-            }
-
-            bodyImageGetter.encode(issue.id(), issue.bodyHtml());
-
-            List<GitHubComment> comments;
-            if(issue.comments() > 0) {
-                comments = getAllComments(repo.owner().login(), repo.name(), issueNumber);
-            } else {
-                comments = Collections.emptyList();
-            }
-
-            for (GitHubComment comment : comments) {
-                commentImageGetter.encode(comment.id(), comment.bodyHtml());
-            }
-
-            List<IssueEvent> events = getAllEvents(repo.owner().login(), repo.name(), issueNumber);
-            emitter.onSuccess(new FullIssue(issue, comments, events));
-        } catch (IOException e){
-            emitter.onError(e);
-        }
+                    return Single.just(issue);
+                })
+                .flatMap(issue -> getAllComments(repo.owner().login(), repo.name(), issue)
+                        .zipWith(Single.just(issue),
+                                (comments, issue1) -> new FullIssue(issue1, comments, null)))
+                .zipWith(getAllEvents(repo.owner().login(), repo.name(), issueNumber),
+                        (fullIssue, issueEvents) -> new FullIssue(fullIssue.getIssue(),
+                                fullIssue.getComments(), issueEvents))
+                .map(fullIssue -> {
+                    Issue issue = fullIssue.getIssue();
+                    bodyImageGetter.encode(issue.id(), issue.bodyHtml());
+                    for (GitHubComment comment : fullIssue.getComments()) {
+                        commentImageGetter.encode(comment.id(), comment.bodyHtml());
+                    }
+                    return fullIssue;
+                });
     }
 
-    private List<GitHubComment> getAllComments(String login, String name, int issueNumber) {
-        List<GitHubComment> comments = new ArrayList<>();
-        int current = 1;
-        int last = -1;
-
-        while(current != last) {
-            Page<GitHubComment> page = ServiceGenerator.createService(context, IssueCommentService.class)
-                    .getIssueComments(login, name, issueNumber, current)
-                    .blockingGet()
-                    .body();
-
-            comments.addAll(page.items());
-            last = page.last() != null ? page.last() : -1;
-            current = page.next() != null ? page.next() : -1;
+    /**
+     * Fetches all comments for a given issue.
+     *
+     * @param login
+     * @param name
+     * @param issue
+     * @return {@link Single}
+     */
+    private Single<List<GitHubComment>> getAllComments(String login, String name, Issue issue) {
+        if (issue.comments() <= 0) {
+            return Single.just(Collections.emptyList());
         }
 
-        return comments;
+        IssueCommentService service = ServiceGenerator.createService(context,
+                IssueCommentService.class);
+        return RxPageUtil.getAllPages(page ->
+                service.getIssueComments(login, name, issue.number(), page), 1)
+                .flatMap(page -> Observable.fromIterable(page.items()))
+                .toList();
     }
 
-    private List<IssueEvent> getAllEvents(String login, String name, int issueNumber) {
-        List<IssueEvent> events = new ArrayList<>();
-        int current = 1;
-        int last = -1;
+    private Single<List<IssueEvent>> getAllEvents(String login, String name, int issueNumber) {
+        IssueEventService service = ServiceGenerator
+                .createService(context, IssueEventService.class);
 
-        while(current != last) {
-            Page<IssueEvent> page = ServiceGenerator.createService(context, IssueEventService.class)
-                    .getIssueEvents(login, name, issueNumber, current)
-                    .blockingGet()
-                    .body();
-
-            events.addAll(page.items());
-            last = page.last() != null ? page.last() : -1;
-            current = page.next() != null ? page.next() : -1;
-        }
-
-        return events;
+        return RxPageUtil.getAllPages(page ->
+                service.getIssueEvents(login, name, issueNumber, page), 1)
+                .flatMap(page -> Observable.fromIterable(page.items()))
+                .toList();
     }
 
-    private PullRequest getPullRequest(String login, String name, int issueNumber) {
+    private Single<PullRequest> getPullRequest(String login, String name,
+                                                         int issueNumber) {
         return ServiceGenerator.createService(context, PullRequestService.class)
                 .getPullRequest(login, name, issueNumber)
-                .blockingGet()
-                .body();
+                .map(Response::body);
     }
+
+
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.java
@@ -149,7 +149,8 @@ public class RepositoryCodeFragment extends DialogFragment implements
 
     private void refreshTree(final GitReference reference) {
         showLoading(true);
-        Single.create(new RefreshTreeTask(getActivity(), repository, reference))
+        new RefreshTreeTask(getActivity(), repository, reference)
+                .refresh()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .compose(this.bindToLifecycle())

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitDiffListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitDiffListFragment.java
@@ -238,7 +238,8 @@ public class CommitDiffListFragment extends DialogFragment implements
     }
 
     private void refreshCommit() {
-        Single.create(new RefreshCommitTask(getActivity(), repository, base, commentImageGetter))
+        new RefreshCommitTask(getActivity(), repository, base, commentImageGetter)
+                .refresh()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .compose(this.bindToLifecycle())

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFilesViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFilesViewActivity.java
@@ -115,7 +115,8 @@ public class GistFilesViewActivity extends PagerActivity {
             loadingBar.setVisibility(View.VISIBLE);
             pager.setVisibility(View.GONE);
             tabs.setVisibility(View.GONE);
-            Single.create(new RefreshGistTask(this, gistId, imageGetter))
+            new RefreshGistTask(this, gistId, imageGetter)
+                    .refresh()
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .compose(this.bindToLifecycle())

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
@@ -400,7 +400,8 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
     }
 
     private void refreshGist() {
-        Single.create(new RefreshGistTask(getActivity(), gistId, imageGetter))
+        new RefreshGistTask(getActivity(), gistId, imageGetter)
+                .refresh()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .filter(fullGist -> isUsable())

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistsPagerFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistsPagerFragment.java
@@ -27,6 +27,7 @@ import android.view.View;
 
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.gist.GistStore;
+import com.github.pockethub.android.rx.ProgressObserverAdapter;
 import com.github.pockethub.android.ui.BaseActivity;
 import com.github.pockethub.android.ui.TabPagerFragment;
 import com.github.pockethub.android.util.ToastUtils;
@@ -37,6 +38,9 @@ import com.meisolsson.githubsdk.service.gists.GistService;
 import com.google.inject.Inject;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -52,51 +56,70 @@ public class GistsPagerFragment extends TabPagerFragment<GistQueriesPagerAdapter
     private static final String TAG = "GistsPagerFragment";
     @Inject
     private GistStore store;
+    private Random rand;
 
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        rand = new Random();
         configureTabPager();
     }
 
     private void randomGist() {
-        Single<Gist> single = Single.create(emitter -> {
-            GistService service = ServiceGenerator.createService(getActivity(), GistService.class);
 
-            Page<Gist> p = service.getPublicGists(1).blockingGet().body();
-            int randomPage = 1 + (int) (Math.random() * ((p.last() - 1) + 1));
+        GistService service = ServiceGenerator.createService(getActivity(), GistService.class);
 
-            Collection<Gist> gists = service.getPublicGists(randomPage)
-                    .blockingGet()
-                    .body()
-                    .items();
+        service.getPublicGists(1)
+                .flatMap(response -> {
+                    Page<Gist> firstPage = response.body();
+                    int randomPage = (int) (Math.random() * (firstPage.last() - 1));
+                    randomPage = Math.max(1, randomPage);
 
-            // Make at least two tries since page numbers are volatile
-            if (gists.isEmpty()) {
-                randomPage = 1 + (int) (Math.random() * ((p.last() - 1) + 1));
-                gists = service.getPublicGists(randomPage).blockingGet().body().items();
-            }
+                    return service.getPublicGists(randomPage);
+                })
+                .flatMap(response -> {
+                    Page<Gist> gistPage = response.body();
+                    if (gistPage.items().isEmpty()) {
+                        int randomPage = (int) (Math.random() * (gistPage.last() - 1));
+                        randomPage = Math.max(1, randomPage);
 
-            if (gists.isEmpty()) {
-                throw new IllegalArgumentException(getContext().getString(
-                        R.string.no_gists_found));
-            }
+                        return service.getPublicGists(randomPage);
+                    }
 
-            emitter.onSuccess(store.addGist(gists.iterator().next()));
-        });
-
-        showProgressIndeterminate(R.string.random_gist);
-        single.subscribeOn(Schedulers.io())
+                    return Single.just(response);
+                })
+                .map(response -> {
+                    Page<Gist> gistPage = response.body();
+                    if (response.isSuccessful()) {
+                        int size = gistPage.items().size();
+                        if (size > 0) {
+                            return store.addGist(gistPage.items().get(rand.nextInt(size)));
+                        } else {
+                            throw new IllegalArgumentException(getContext().getString(
+                                    R.string.no_gists_found));
+                        }
+                    } else {
+                        ToastUtils.show(getActivity(), R.string.error_gist_load);
+                        return null;
+                    }
+                })
+                .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .compose(((BaseActivity)getActivity()).bindToLifecycle())
-                .subscribe(gist -> {
-                    getActivity().startActivityForResult(
-                            GistsViewActivity.createIntent(gist), GIST_VIEW);
-                    dismissProgress();
-                }, e -> {
-                    Log.d(TAG, "Exception opening random Gist", e);
-                    ToastUtils.show((Activity) getContext(), e.getMessage());
-                    dismissProgress();
+                .subscribe(new ProgressObserverAdapter<Gist>(getActivity(), R.string.random_gist) {
+                    @Override
+                    public void onSuccess(Gist gist) {
+                        super.onSuccess(gist);
+                        getActivity().startActivityForResult(
+                                GistsViewActivity.createIntent(gist), GIST_VIEW);
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        super.onError(e);
+                        Log.d(TAG, "Exception opening random Gist", e);
+                        ToastUtils.show((Activity) getContext(), e.getMessage());
+                    }
                 });
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditMilestoneTask.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditMilestoneTask.java
@@ -39,7 +39,7 @@ import static com.github.pockethub.android.RequestCodes.ISSUE_MILESTONE_UPDATE;
 /**
  * Task to edit a milestone
  */
-public class EditMilestoneTask implements SingleOnSubscribe<Issue> {
+public class EditMilestoneTask {
 
     @Inject
     private IssueStore store;
@@ -76,16 +76,6 @@ public class EditMilestoneTask implements SingleOnSubscribe<Issue> {
         RoboGuice.injectMembers(activity, this);
     }
 
-    @Override
-    public void subscribe(SingleEmitter<Issue> emitter) throws Exception {
-        try {
-            IssueRequest editedIssue = IssueRequest.builder().milestone(milestoneNumber).build();
-            emitter.onSuccess(store.editIssue(repositoryId, issueNumber, editedIssue));
-        } catch (IOException e) {
-            emitter.onError(e);
-        }
-    }
-
     /**
      * Prompt for milestone selection
      *
@@ -104,10 +94,10 @@ public class EditMilestoneTask implements SingleOnSubscribe<Issue> {
      * @return this task
      */
     public EditMilestoneTask edit(Milestone milestone) {
-        if (milestone != null)
+        if (milestone != null) {
+            IssueRequest editedIssue = IssueRequest.builder().milestone(milestoneNumber).build();
 
-        {
-            Single.create(this)
+            store.editIssue(repositoryId, issueNumber, editedIssue)
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .compose(activity.bindToLifecycle())

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
@@ -408,7 +408,9 @@ public class IssueFragment extends DialogFragment {
     }
 
     private void refreshIssue() {
-        Single.create(new RefreshIssueTask(getActivity(), repositoryId, issueNumber, bodyImageGetter, commentImageGetter))
+        new RefreshIssueTask(getActivity(), repositoryId, issueNumber,
+                bodyImageGetter, commentImageGetter)
+                .refresh()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .filter(fullIssue -> isUsable())

--- a/app/src/main/java/com/github/pockethub/android/ui/search/SearchRepositoryListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/search/SearchRepositoryListFragment.java
@@ -22,6 +22,7 @@ import android.text.TextUtils;
 import android.view.View;
 import android.widget.ListView;
 
+import com.github.pockethub.android.util.ToastUtils;
 import com.meisolsson.githubsdk.core.ServiceGenerator;
 import com.meisolsson.githubsdk.model.Page;
 import com.meisolsson.githubsdk.model.Repository;
@@ -147,17 +148,18 @@ public class SearchRepositoryListFragment extends PagedItemFragment<Repository> 
             return false;
         }
 
-        Repository repo;
-        repo = ServiceGenerator.createService(getContext(), RepositoryService.class)
+        ServiceGenerator.createService(getContext(), RepositoryService.class)
                 .getRepository(repoId.owner().login(), repoId.name())
-                .blockingGet()
-                .body();
+                .subscribe(response -> {
+                    if (response.isSuccessful()) {
+                        startActivity(RepositoryViewActivity.createIntent(response.body()));
+                        final Activity activity = getActivity();
+                        if (activity != null) {
+                            activity.finish();
+                        }
+                    }
+                });
 
-        startActivity(RepositoryViewActivity.createIntent(repo));
-        final Activity activity = getActivity();
-        if (activity != null) {
-            activity.finish();
-        }
         return true;
     }
 

--- a/app/src/main/java/com/github/pockethub/android/util/RxPageUtil.java
+++ b/app/src/main/java/com/github/pockethub/android/util/RxPageUtil.java
@@ -1,0 +1,30 @@
+package com.github.pockethub.android.util;
+
+import com.github.pockethub.android.core.PageIterator;
+import com.meisolsson.githubsdk.model.Page;
+
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+import retrofit2.Response;
+
+public class RxPageUtil {
+
+    public static  <B> Observable<Page<B>> getAllPages(
+            PageIterator.GitHubRequest<Response<Page<B>>> pagedSingleCall, int i) {
+
+        return pagedSingleCall.execute(i)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .flatMapObservable(response -> {
+                    Page<B> page = response.body();
+                    if (page.next() == null) {
+                        return Observable.just(page);
+                    }
+
+                    return Observable.just(page)
+                            .concatWith(getAllPages(pagedSingleCall, page.next()));
+
+                });
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -323,6 +323,8 @@ Read the README.md: https://github.com/pockethub/PocketHub#setup-environment</st
     <string name="no_notifications">No notifications found</string>
     <string name="error_notifications_load">Error loading notifications</string>
     <string name="releases_not_yet_in_app">Sorry, we don\'t support releases in the app yet</string>
+    <string name="error_edit_issue">Could not edit issue</string>
+    <string name="error_issue_state">Could not change state</string>
 
 
     <string-array name="welcome_texts">


### PR DESCRIPTION
These have been the biggest cause of crashes due to the fact that we never to into account that the request could fail. The fix for this is to stop using Observable.create and instead use the actual Single/Observable which is returned by Retrofit.

This will basically reduce crashed when switching between activities.