### PR TITLE
Issues were not refreshed on user request

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesFragment.java
@@ -209,6 +209,9 @@ public class IssuesFragment extends PagedItemFragment<Issue> {
             return false;
         }
         switch (item.getItemId()) {
+            case R.id.m_refresh:
+                forceRefresh();
+            return true;
         case R.id.create_issue:
             startActivityForResult(EditIssueActivity.createIntent(repository),
                     ISSUE_CREATE);


### PR DESCRIPTION
We never refreshed the issues when the user clicked the button.