### PR TITLE
Remove redundant null checks

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/NewsFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/NewsFragment.java
@@ -233,7 +233,7 @@ public abstract class NewsFragment extends PagedItemFragment<GitHubEvent> {
 
         PushPayload payload = ((PushPayload) event.payload());
         List<GitCommit> commits = payload.commits();
-        if (commits == null || commits.isEmpty()) {
+        if (commits.isEmpty()) {
             return;
         }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareListFragment.java
@@ -131,9 +131,7 @@ public class CommitCompareListFragment extends DialogFragment implements
                     CommitCompare compareCommit = response.body();
                     List<GitHubFile> files = compareCommit.files();
                     diffStyler.setFiles(files);
-                    if (files != null) {
-                        Collections.sort(files, new CommitFileComparator());
-                    }
+                    Collections.sort(files, new CommitFileComparator());
                     updateList(compareCommit);
                 }, error -> ToastUtils.show(getActivity(), error, R.string.error_commits_load));
     }
@@ -174,7 +172,7 @@ public class CommitCompareListFragment extends DialogFragment implements
         CommitFileListAdapter rootAdapter = adapter.getWrappedAdapter();
         rootAdapter.clear();
         List<GitHubFile> files = compare.files();
-        if (files != null && !files.isEmpty()) {
+        if (!files.isEmpty()) {
             addFileStatHeader(files, inflater);
             for (GitHubFile file : files) {
                 rootAdapter.addItem(file);

--- a/app/src/main/java/com/github/pockethub/android/ui/user/IconAndViewTextManager.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/user/IconAndViewTextManager.java
@@ -370,7 +370,7 @@ public class IconAndViewTextManager {
         boldRepo(main, event);
 
         final List<GitCommit> commits = payload.commits();
-        int size = commits != null ? commits.size() : -1;
+        int size = commits.size();
         if (size > 0) {
             if (size != 1) {
                 details.append(FORMAT_INT.format(size)).append(" new commits");


### PR DESCRIPTION
In GithubSdk, these methods are marked as returning a NonNull value so we should rely on that being true.