### PR TITLE
Remove redundant null check for Uri#getPathSegments()

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/core/commit/CommitUriMatcher.java
+++ b/app/src/main/java/com/github/pockethub/android/core/commit/CommitUriMatcher.java
@@ -36,9 +36,6 @@ public class CommitUriMatcher {
      */
     public static CommitMatch getCommit(Uri uri) {
         List<String> segments = uri.getPathSegments();
-        if (segments == null) {
-            return null;
-        }
         if (segments.size() < 4) {
             return null;
         }

--- a/app/src/main/java/com/github/pockethub/android/core/gist/GistUriMatcher.java
+++ b/app/src/main/java/com/github/pockethub/android/core/gist/GistUriMatcher.java
@@ -39,9 +39,6 @@ public class GistUriMatcher {
      */
     public static Gist getGist(final Uri uri) {
         List<String> segments = uri.getPathSegments();
-        if (segments == null) {
-            return null;
-        }
         if (segments.size() != 1) {
             return null;
         }

--- a/app/src/main/java/com/github/pockethub/android/core/issue/IssueUriMatcher.java
+++ b/app/src/main/java/com/github/pockethub/android/core/issue/IssueUriMatcher.java
@@ -39,9 +39,6 @@ public class IssueUriMatcher {
      */
     public static Issue getIssue(Uri uri) {
         List<String> segments = uri.getPathSegments();
-        if (segments == null) {
-            return null;
-        }
         if (segments.size() < 4) {
             return null;
         }

--- a/app/src/main/java/com/github/pockethub/android/core/repo/RepositoryUriMatcher.java
+++ b/app/src/main/java/com/github/pockethub/android/core/repo/RepositoryUriMatcher.java
@@ -35,9 +35,6 @@ public class RepositoryUriMatcher {
      */
     public static Repository getRepository(Uri uri) {
         List<String> segments = uri.getPathSegments();
-        if (segments == null) {
-            return null;
-        }
         if (segments.size() < 2) {
             return null;
         }

--- a/app/src/main/java/com/github/pockethub/android/core/user/UserUriMatcher.java
+++ b/app/src/main/java/com/github/pockethub/android/core/user/UserUriMatcher.java
@@ -35,9 +35,6 @@ public class UserUriMatcher {
      */
     public static User getUser(Uri uri) {
         List<String> segments = uri.getPathSegments();
-        if (segments == null) {
-            return null;
-        }
         if (segments.size() < 1) {
             return null;
         }


### PR DESCRIPTION
`Uri#getPathSegments` is never `null`. This is confirmed by looking at the [docs](https://developer.android.com/reference/android/net/Uri.html#getPathSegments()) which doesn't state that `null` is ever returned,  and by looking through the Android source code, where `getPathSegments` is assumed to be non `null` throughout the code.