### PR TITLE
Fix issues loading fail

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/core/issue/RefreshIssueTask.java
+++ b/app/src/main/java/com/github/pockethub/android/core/issue/RefreshIssueTask.java
@@ -100,7 +100,7 @@ public class RefreshIssueTask {
                 })
                 .flatMap(issue -> getAllComments(repo.owner().login(), repo.name(), issue)
                         .zipWith(Single.just(issue),
-                                (comments, issue1) -> new FullIssue(issue1, comments, null)))
+                                (comments, issue1) -> new FullIssue(issue1, comments, Collections.emptyList())))
                 .zipWith(getAllEvents(repo.owner().login(), repo.name(), issueNumber),
                         (fullIssue, issueEvents) -> new FullIssue(fullIssue.getIssue(),
                                 fullIssue.getComments(), issueEvents))


### PR DESCRIPTION
I'm not sure whether that relates to #1100 or not, the description there was not clear enough.

This is something that I've discovered myself, `com.github.pockethub.android.ui.issue.IssueFragment` was showing an error and an empty list due to null arguments being passed somewhere along the Rx workflow in `refreshIssue()`. This has now been fixed. 