### PR TITLE
"android:value" needs absolute paths

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,7 @@
 
             <meta-data
                 android:name="android.app.default_searchable"
-                android:value=".ui.search.SearchActivity" />
+                android:value="com.github.pockethub.android.ui.search.SearchActivity" />
         </activity>
         <activity
             android:name=".ui.gist.CreateGistActivity"
@@ -53,7 +53,7 @@
             tools:ignore="UnusedAttribute">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value=".ui.MainActivity" />
+                android:value="com.github.pockethub.android.ui.MainActivity" />
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -69,7 +69,7 @@
 
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value=".ui.MainActivity" />
+                android:value="com.github.pockethub.android.ui.MainActivity" />
         </activity>
         <activity
             android:name=".ui.issue.IssueBrowseActivity"
@@ -83,7 +83,7 @@
 
             <meta-data
                 android:name="android.app.default_searchable"
-                android:value=".ui.issue.IssueSearchActivity" />
+                android:value="com.github.pockethub.android.ui.issue.IssueSearchActivity" />
         </activity>
         <activity
             android:name=".ui.issue.EditIssuesFilterActivity"
@@ -202,7 +202,7 @@
 
             <meta-data
                 android:name="android.app.default_searchable"
-                android:value=".ui.issue.IssueSearchActivity" />
+                android:value="com.github.pockethub.android.ui.issue.IssueSearchActivity" />
         </activity>
         <activity
             android:name=".ui.repo.RepositoryContributorsActivity"


### PR DESCRIPTION
This was a miss on my part while adding support for separate debug builds. Basically these need to be absolute.

This fixes: 
- Search in the app
- Back navigation on API < 16