### PR TITLE
Fix gist list crash

### DIFF
--- a/app/src/androidTest/java/com/github/pockethub/android/tests/gist/GistItemTest.java
+++ b/app/src/androidTest/java/com/github/pockethub/android/tests/gist/GistItemTest.java
@@ -1,0 +1,30 @@
+package com.github.pockethub.android.tests.gist;
+
+
+import android.test.AndroidTestCase;
+
+import com.github.pockethub.android.ui.item.gist.GistItem;
+import com.github.pockethub.android.util.AvatarLoader;
+import com.meisolsson.githubsdk.model.Gist;
+import com.meisolsson.githubsdk.model.User;
+
+public class GistItemTest extends AndroidTestCase {
+
+    public void testGroupieGistItemPosition() {
+
+        User user = User.builder()
+                .name("user")
+                .build();
+
+        Gist gist = Gist.builder()
+                .owner(user)
+                .id("gistid")
+                .build();
+
+        AvatarLoader loader = new AvatarLoader(getContext());
+        GistItem item = new GistItem(loader, gist);
+        GistItem otherItem = new GistItem(loader, gist);
+
+        assertEquals(0, item.getPosition(otherItem));
+    }
+}

--- a/app/src/main/java/com/github/pockethub/android/ui/item/BaseDataItem.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/item/BaseDataItem.java
@@ -27,6 +27,11 @@ public abstract class BaseDataItem<T, V extends BaseViewHolder> extends Item<V> 
     }
 
     @Override
+    public int getPosition(@NonNull Item item) {
+        return this.isSameAs(item) ? 0 : -1;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj instanceof BaseDataItem) {
             return getData().equals(((BaseDataItem) obj).getData());


### PR DESCRIPTION
Steps to reproduce:
- open any gist from the gist list
- tap the Back button
- try opening a different gist
This fixes the issue. Identical gists didn't seem to pass Groupie's positional identity test.