### PR TITLE
Set content view using native method directly

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/accounts/LoginActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/accounts/LoginActivity.java
@@ -95,6 +95,7 @@ public class LoginActivity extends AccountAuthenticatorAppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.login);
 
         clientId = getString(R.string.github_client);
         secret = getString(R.string.github_secret);
@@ -108,11 +109,6 @@ public class LoginActivity extends AccountAuthenticatorAppCompatActivity {
             openMain();
         }
         checkOauthConfig();
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.login;
     }
 
     private void checkOauthConfig() {

--- a/app/src/main/java/com/github/pockethub/android/ui/BaseActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/BaseActivity.java
@@ -43,9 +43,8 @@ public abstract class BaseActivity extends DaggerAppCompatActivity implements Di
     protected Toolbar toolbar;
 
     @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(getContentView());
+    public void onContentChanged() {
+        super.onContentChanged();
         ButterKnife.bind(this);
         setSupportActionBar(toolbar);
     }
@@ -129,12 +128,4 @@ public abstract class BaseActivity extends DaggerAppCompatActivity implements Di
     public void onDialogResult(int requestCode, int resultCode, Bundle arguments) {
         // Intentionally left blank
     }
-
-    /**
-     * Get content view to be used when {@link #onCreate(Bundle)} is called.
-     *
-     * @return layout resource id
-     */
-    @LayoutRes
-    protected abstract int getContentView();
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/MainActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/MainActivity.java
@@ -115,6 +115,8 @@ public class MainActivity extends BaseActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
         userLearnedDrawer = sp.getBoolean(PREF_USER_LEARNED_DRAWER, false);
 
@@ -150,11 +152,6 @@ public class MainActivity extends BaseActivity
                 tokenStore.saveToken(AccountsHelper.getUserToken(this, account));
             }
         }
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_main;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/TabPagerActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/TabPagerActivity.java
@@ -16,6 +16,7 @@
 package com.github.pockethub.android.ui;
 
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.design.widget.TabLayout;
 import android.support.v4.view.PagerAdapter;
 import android.support.v7.widget.Toolbar;
@@ -121,11 +122,6 @@ public abstract class TabPagerActivity<V extends PagerAdapter & FragmentProvider
         // Intentionally left blank
     }
 
-    @Override
-    protected int getContentView() {
-        return R.layout.pager_with_tabs;
-    }
-
     private void updateCurrentItem(final int newPosition) {
         if (newPosition > -1 && newPosition < adapter.getCount()) {
             pager.setItem(newPosition);
@@ -154,8 +150,8 @@ public abstract class TabPagerActivity<V extends PagerAdapter & FragmentProvider
     }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(@Nullable Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
 
         // On Lollipop, the action bar shadow is provided by default, so have to remove it explicitly
         getSupportActionBar().setElevation(0);

--- a/app/src/main/java/com/github/pockethub/android/ui/comment/CreateCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/comment/CreateCommentActivity.java
@@ -17,6 +17,7 @@ package com.github.pockethub.android.ui.comment;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -48,8 +49,8 @@ public abstract class CreateCommentActivity extends
     protected AvatarLoader avatars;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(@Nullable Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareViewActivity.java
@@ -70,6 +70,7 @@ public class CommitCompareViewActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.commit_compare);
 
         repository = getIntent().getParcelableExtra(EXTRA_REPOSITORY);
 
@@ -80,11 +81,6 @@ public class CommitCompareViewActivity extends BaseActivity {
 
         fragment = getSupportFragmentManager()
             .findFragmentById(android.R.id.list);
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.commit_compare;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitFileViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitFileViewActivity.java
@@ -123,6 +123,7 @@ public class CommitFileViewActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_commit_file_view);
 
         repo = getIntent().getParcelableExtra(EXTRA_REPOSITORY);
         commit = getStringExtra(EXTRA_HEAD);
@@ -148,11 +149,6 @@ public class CommitFileViewActivity extends BaseActivity {
         avatars.bind(actionBar, repo.owner());
 
         loadContent();
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_commit_file_view;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitViewActivity.java
@@ -116,6 +116,7 @@ public class CommitViewActivity extends PagerActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_pager);
 
         repository = getIntent().getParcelableExtra(EXTRA_REPOSITORY);
         ids = getCharSequenceArrayExtra(EXTRA_BASES);
@@ -137,11 +138,6 @@ public class CommitViewActivity extends PagerActivity {
     protected void onDestroy() {
         super.onDestroy();
         pager.removeOnPageChangeListener(this);
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_pager;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CreateCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CreateCommentActivity.java
@@ -98,6 +98,7 @@ public class CreateCommentActivity extends
         path = getStringExtra(EXTRA_PATH);
 
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.pager_with_tabs);
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(getString(R.string.commit_prefix)

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/CreateCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/CreateCommentActivity.java
@@ -60,6 +60,7 @@ public class CreateCommentActivity extends
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.pager_with_tabs);
 
         gist = getParcelableExtra(EXTRA_GIST);
 

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/CreateGistActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/CreateGistActivity.java
@@ -79,6 +79,8 @@ public class CreateGistActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_gist_create);
+
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
 
@@ -93,11 +95,6 @@ public class CreateGistActivity extends BaseActivity {
         }
 
         updateCreateMenu();
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_gist_create;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/EditCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/EditCommentActivity.java
@@ -72,6 +72,7 @@ public class EditCommentActivity extends
         gist = getParcelableExtra(EXTRA_GIST);
         comment = getIntent().getParcelableExtra(EXTRA_COMMENT);
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.pager_with_tabs);
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(getString(R.string.gist_title) + gist.id());

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFilesViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFilesViewActivity.java
@@ -95,6 +95,7 @@ public class GistFilesViewActivity extends PagerActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_pager_with_title);
 
         gistId = getStringExtra(EXTRA_GIST_ID);
         initialPosition = getIntExtra(EXTRA_POSITION);
@@ -122,11 +123,6 @@ public class GistFilesViewActivity extends PagerActivity {
                         configurePager();
                     });
         }
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_pager_with_title;
     }
 
     private void configurePager() {

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.java
@@ -115,6 +115,7 @@ public class GistsViewActivity extends PagerActivity implements OnLoadListener<G
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_pager);
 
         gists = getStringArrayExtra(EXTRA_GIST_IDS);
         gist = getParcelableExtra(EXTRA_GIST);
@@ -145,11 +146,6 @@ public class GistsViewActivity extends PagerActivity implements OnLoadListener<G
     protected void onDestroy() {
         super.onDestroy();
         pager.removeOnPageChangeListener(this);
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_pager;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/CreateCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/CreateCommentActivity.java
@@ -71,6 +71,7 @@ public class CreateCommentActivity extends
         repositoryId = getParcelableExtra(Intents.EXTRA_REPOSITORY);
 
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.pager_with_tabs);
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(getString(R.string.issue_title) + issueNumber);

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditCommentActivity.java
@@ -85,6 +85,7 @@ public class EditCommentActivity extends
         repositoryId = getParcelableExtra(Intents.EXTRA_REPOSITORY);
 
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.pager_with_tabs);
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(getString(R.string.issue_title) + issueNumber);

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditIssueActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditIssueActivity.java
@@ -178,6 +178,8 @@ public class EditIssueActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_issue_edit);
+
         Intent intent = getIntent();
 
         if (savedInstanceState != null) {
@@ -214,11 +216,6 @@ public class EditIssueActivity extends BaseActivity {
         updateSaveMenu();
         titleText.setText(issue.title());
         bodyText.setText(issue.body());
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_issue_edit;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditIssuesFilterActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditIssuesFilterActivity.java
@@ -97,6 +97,8 @@ public class EditIssuesFilterActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_issues_filter_edit);
+
         if (savedInstanceState != null) {
             filter = savedInstanceState.getParcelable(EXTRA_ISSUE_FILTER);
         }
@@ -150,11 +152,6 @@ public class EditIssuesFilterActivity extends BaseActivity {
             default:
                 break;
         }
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_issues_filter_edit;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/FiltersViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/FiltersViewActivity.java
@@ -64,6 +64,7 @@ public class FiltersViewActivity extends BaseActivity implements OnItemLongClick
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.issues_filter_list);
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(R.string.bookmarks);
@@ -73,11 +74,6 @@ public class FiltersViewActivity extends BaseActivity implements OnItemLongClick
         fragment = (FilterListFragment) getSupportFragmentManager()
             .findFragmentById(android.R.id.list);
         fragment.getListAdapter().setOnItemLongClickListener(this);
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.issues_filter_list;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueBrowseActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueBrowseActivity.java
@@ -58,6 +58,7 @@ public class IssueBrowseActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_repo_issue_list);
 
         repo = getParcelableExtra(EXTRA_REPOSITORY);
 
@@ -66,11 +67,6 @@ public class IssueBrowseActivity extends BaseActivity {
         actionBar.setSubtitle(repo.owner().login());
         actionBar.setDisplayHomeAsUpEnabled(true);
         avatars.bind(actionBar, repo.owner());
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_repo_issue_list;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueSearchActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueSearchActivity.java
@@ -96,6 +96,7 @@ public class IssueSearchActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_issue_search);
 
         ActionBar actionBar = getSupportActionBar();
         Bundle appData = getIntent().getBundleExtra(APP_DATA);
@@ -112,11 +113,6 @@ public class IssueSearchActivity extends BaseActivity {
             .findFragmentById(android.R.id.list);
 
         handleIntent(getIntent());
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_issue_search;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.java
@@ -177,6 +177,8 @@ public class IssuesViewActivity extends PagerActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_pager);
+
         issueNumbers = getIntArrayExtra(EXTRA_ISSUE_NUMBERS);
         pullRequests = getBooleanArrayExtra(EXTRA_PULL_REQUESTS);
         repoIds = getIntent().getParcelableArrayListExtra(EXTRA_REPOSITORIES);
@@ -209,11 +211,6 @@ public class IssuesViewActivity extends PagerActivity {
     protected void onDestroy() {
         super.onDestroy();
         pager.removeOnPageChangeListener(this);
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_pager;
     }
 
     private void repositoryLoaded(Repository repo) {

--- a/app/src/main/java/com/github/pockethub/android/ui/notification/NotificationActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/notification/NotificationActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.view.MenuItem;
 
+import com.github.pockethub.android.R;
 import com.github.pockethub.android.ui.TabPagerActivity;
 
 public class NotificationActivity extends TabPagerActivity<NotificationPagerAdapter> {
@@ -11,6 +12,8 @@ public class NotificationActivity extends TabPagerActivity<NotificationPagerAdap
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.pager_with_tabs);
+
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
 

--- a/app/src/main/java/com/github/pockethub/android/ui/ref/BranchFileViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/ref/BranchFileViewActivity.java
@@ -126,6 +126,7 @@ public class BranchFileViewActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_commit_file_view);
 
         repo = getParcelableExtra(EXTRA_REPOSITORY);
         sha = getStringExtra(EXTRA_BASE);
@@ -147,11 +148,6 @@ public class BranchFileViewActivity extends BaseActivity {
         avatars.bind(actionBar, repo.owner());
 
         loadContent();
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_commit_file_view;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryContributorsActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryContributorsActivity.java
@@ -56,6 +56,8 @@ public class RepositoryContributorsActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_repo_contributors);
+
         repository = getParcelableExtra(EXTRA_REPOSITORY);
 
         ActionBar actionBar = getSupportActionBar();
@@ -65,11 +67,6 @@ public class RepositoryContributorsActivity extends BaseActivity {
 
         User owner = repository.owner();
         avatars.bind(getSupportActionBar(), owner);
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.activity_repo_contributors;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.java
@@ -95,6 +95,7 @@ public class RepositoryViewActivity extends TabPagerActivity<RepositoryPagerAdap
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.tabbed_progress_pager);
 
         repository = getParcelableExtra(EXTRA_REPOSITORY);
         User owner = repository.owner();
@@ -235,11 +236,6 @@ public class RepositoryViewActivity extends TabPagerActivity<RepositoryPagerAdap
     @Override
     protected RepositoryPagerAdapter createAdapter() {
         return new RepositoryPagerAdapter(this, repository.hasIssues(), hasReadme);
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.tabbed_progress_pager;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/search/SearchActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/search/SearchActivity.java
@@ -61,6 +61,7 @@ public class SearchActivity extends TabPagerActivity<SearchPagerAdapter> {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.tabbed_progress_pager);
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
@@ -104,11 +105,6 @@ public class SearchActivity extends TabPagerActivity<SearchPagerAdapter> {
     @Override
     protected SearchPagerAdapter createAdapter() {
         return new SearchPagerAdapter(this);
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.tabbed_progress_pager;
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/user/UserViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/user/UserViewActivity.java
@@ -85,6 +85,7 @@ public class UserViewActivity extends TabPagerActivity<UserPagerAdapter>
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.tabbed_progress_pager);
 
         user = getIntent().getParcelableExtra(EXTRA_USER);
 
@@ -169,11 +170,6 @@ public class UserViewActivity extends TabPagerActivity<UserPagerAdapter>
     @Override
     protected UserPagerAdapter createAdapter() {
         return new UserPagerAdapter(this);
-    }
-
-    @Override
-    protected int getContentView() {
-        return R.layout.tabbed_progress_pager;
     }
 
     @Override


### PR DESCRIPTION
[`onContentChanged()`](https://developer.android.com/reference/android/app/Activity.html#onContentChanged()) documentation:

> This hook is called whenever the content view of the screen changes (due to a call to Window.setContentView or Window.addContentView).

This method achieves what overriding `BaseActivity#onCreate(Bundle)` is trying to achieve but in a much more elegant way.