### PR TITLE
Remove ToastUtils exception method

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/ItemListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/ItemListFragment.java
@@ -287,7 +287,7 @@ public abstract class ItemListFragment<E> extends BaseFragment implements
      * @param defaultMessage
      */
     protected void showError(final Throwable e, final int defaultMessage) {
-        ToastUtils.show(getActivity(), e, defaultMessage);
+        ToastUtils.show(getActivity(), defaultMessage);
     }
 
     /**

--- a/app/src/main/java/com/github/pockethub/android/ui/MainActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/MainActivity.java
@@ -187,7 +187,7 @@ public class MainActivity extends BaseActivity
                 .subscribe(this::onOrgsLoaded,
                         e -> {
                             Log.e(TAG, "Exception loading organizations", e);
-                            ToastUtils.show(this, e, R.string.error_orgs_load);
+                            ToastUtils.show(this, R.string.error_orgs_load);
                         });
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.java
@@ -197,7 +197,7 @@ public class RepositoryCodeFragment extends BaseFragment implements OnItemClickL
                     Log.d(TAG, "Exception loading tree", e);
 
                     showLoading(false);
-                    ToastUtils.show(getActivity(), e, R.string.error_code_load);
+                    ToastUtils.show(getActivity(), R.string.error_code_load);
                 });
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareListFragment.java
@@ -173,7 +173,7 @@ public class CommitCompareListFragment extends BaseFragment implements OnItemCli
                     diffStyler.setFiles(files);
                     Collections.sort(files, new CommitFileComparator());
                     updateList(compareCommit);
-                }, error -> ToastUtils.show(getActivity(), error, R.string.error_commits_load));
+                }, error -> ToastUtils.show(getActivity(), R.string.error_commits_load));
     }
 
     private void updateList(CommitCompare compare) {

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitDiffListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitDiffListFragment.java
@@ -269,7 +269,7 @@ public class CommitDiffListFragment extends BaseFragment implements OnItemClickL
 
                     updateList(full.getCommit(), full, full.getFiles());
                 }, e -> {
-                    ToastUtils.show(getActivity(), e, R.string.error_commit_load);
+                    ToastUtils.show(getActivity(), R.string.error_commit_load);
                     progress.setVisibility(View.GONE);
                 });
     }

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitFileViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitFileViewActivity.java
@@ -278,7 +278,7 @@ public class CommitFileViewActivity extends BaseActivity {
 
                     loadingBar.setVisibility(View.GONE);
                     codeView.setVisibility(View.VISIBLE);
-                    ToastUtils.show(this, error, R.string.error_file_load);
+                    ToastUtils.show(this, R.string.error_file_load);
                 });
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFileFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFileFragment.java
@@ -169,7 +169,7 @@ public class GistFileFragment extends BaseFragment implements
                     if (file.content() != null) {
                         showSource();
                     }
-                }, e -> ToastUtils.show(getActivity(), e, R.string.error_gist_file_load));
+                }, e -> ToastUtils.show(getActivity(), R.string.error_gist_file_load));
     }
 
     private void showSource() {

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
@@ -371,7 +371,7 @@ public class GistFragment extends BaseFragment implements OnItemClickListener, D
                     gist = fullGist.getGist();
                     comments = fullGist.getComments();
                     updateList(fullGist.getGist(), fullGist.getComments());
-                }, e -> ToastUtils.show(getActivity(), e, R.string.error_gist_load));
+                }, e -> ToastUtils.show(getActivity(), R.string.error_gist_load));
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/AssigneeDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/AssigneeDialog.java
@@ -94,7 +94,7 @@ public class AssigneeDialog {
                     checked);
         }, error -> {
             Log.d(TAG, "Exception loading collaborators", error);
-            ToastUtils.show(activity, error, R.string.error_collaborators_load);
+            ToastUtils.show(activity, R.string.error_collaborators_load);
         });
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
@@ -262,7 +262,7 @@ public class IssueFragment extends BaseFragment
                     items.addAll(fullIssue.getComments());
                     updateList(fullIssue.getIssue(), items);
                 }, e -> {
-                    ToastUtils.show(getActivity(), e, R.string.error_issue_load);
+                    ToastUtils.show(getActivity(), R.string.error_issue_load);
                     progress.setVisibility(GONE);
                 });
     }

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/LabelsDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/LabelsDialog.java
@@ -100,7 +100,7 @@ public class LabelsDialog {
                     activity.getString(R.string.select_labels), null, new ArrayList<>(labels), checked);
         }, error -> {
             Log.e(TAG, "Exception loading labels", error);
-            ToastUtils.show(activity, error, R.string.error_labels_load);
+            ToastUtils.show(activity, R.string.error_labels_load);
         });
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/MilestoneDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/MilestoneDialog.java
@@ -96,7 +96,7 @@ public class MilestoneDialog {
                     new ArrayList<>(milestones), checked);
         }, error -> {
             Log.e(TAG, "Exception loading milestones", error);
-            ToastUtils.show(activity, error, R.string.error_milestones_load);
+            ToastUtils.show(activity, R.string.error_milestones_load);
         });
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/ref/BranchFileViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/ref/BranchFileViewActivity.java
@@ -274,7 +274,7 @@ public class BranchFileViewActivity extends BaseActivity {
 
                     loadingBar.setVisibility(View.GONE);
                     codeView.setVisibility(View.VISIBLE);
-                    ToastUtils.show(this, e, R.string.error_file_load);
+                    ToastUtils.show(this, R.string.error_file_load);
                 });
     }
 

--- a/app/src/main/java/com/github/pockethub/android/ui/ref/RefDialog.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/ref/RefDialog.java
@@ -101,7 +101,7 @@ public class RefDialog {
                     activity.getString(R.string.select_ref), null, new ArrayList<>(refs), checked);
         }, e -> {
             Log.d(TAG, "Exception loading references", e);
-            ToastUtils.show(activity, e, R.string.error_refs_load);
+            ToastUtils.show(activity, R.string.error_refs_load);
         });
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/util/ToastUtils.java
+++ b/app/src/main/java/com/github/pockethub/android/util/ToastUtils.java
@@ -50,27 +50,4 @@ public class ToastUtils {
 
         show(activity, activity.getString(resId));
     }
-
-    /**
-     * Show {@link Toast} for throwable
-     * <p>
-     * This given default message will be used if an message can not be derived
-     * from the given {@link Exception}
-     * <p>
-     * This method may be called from any thread
-     *
-     * @param activity
-     * @param e
-     * @param defaultMessage
-     */
-    public static void show(final Activity activity, final Throwable e,
-            final int defaultMessage) {
-        if (activity == null) {
-            return;
-        }
-
-        String message = activity.getString(defaultMessage);
-
-        show(activity, message);
-    }
 }


### PR DESCRIPTION
`ToastUtils.show(Activity, Throwable, int)` doesn't follow its Javadoc specification. It is functionally equivalent to `ToastUtils.show(Activity, int)`. The two options here were to either fix the method so it does abide to its specification, or delete the method. I opted to delete the method as showing the error message to the user seems ugly and ultimately pointless as the error message will be dependent on the apps implementation, something the user shouldn't need to care about.