### PR TITLE
Update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,27 +139,27 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
-    def supportVersion = '27.0.2'
+    def supportVersion = '27.1.0'
     implementation "com.android.support:appcompat-v7:$supportVersion"
     implementation "com.android.support:support-v4:$supportVersion"
     implementation "com.android.support:design:$supportVersion"
 
     implementation 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.1.0'
-    implementation 'com.squareup.okhttp3:okhttp:3.8.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
 
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    implementation 'io.reactivex.rxjava2:rxjava:2.1.7'
-    implementation 'com.uber.autodispose:autodispose:0.5.1'
-    implementation 'com.uber.autodispose:autodispose-android-archcomponents:0.5.1'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.10'
+    implementation 'com.uber.autodispose:autodispose:0.6.1'
+    implementation 'com.uber.autodispose:autodispose-android-archcomponents:0.6.1'
 
-    implementation 'com.bugsnag:bugsnag-android:3.6.0'
+    implementation 'com.bugsnag:bugsnag-android:4.3.1'
 
-    implementation 'com.google.dagger:dagger:2.13'
-    implementation 'com.google.dagger:dagger-android:2.13'
-    implementation 'com.google.dagger:dagger-android-support:2.13'
+    implementation 'com.google.dagger:dagger:2.15'
+    implementation 'com.google.dagger:dagger-android:2.15'
+    implementation 'com.google.dagger:dagger-android-support:2.15'
 
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.13'
-    annotationProcessor 'com.google.dagger:dagger-android-processor:2.13'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.15'
+    annotationProcessor 'com.google.dagger:dagger-android-processor:2.15'
 
     compileOnly 'com.episode6.hackit.auto.factory:auto-factory-annotations:1.0-beta5'
     annotationProcessor 'com.google.auto.factory:auto-factory:1.0-beta5'
@@ -174,6 +174,6 @@ dependencies {
     //Libs for testing
     testImplementation 'junit:junit:4.12'
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-    testImplementation "org.mockito:mockito-core:1.9.5"
-    testImplementation "org.robolectric:robolectric:3.6.1"
+    testImplementation "org.mockito:mockito-core:2.15.0"
+    testImplementation "org.robolectric:robolectric:3.7.1"
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditLabelsTask.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditLabelsTask.java
@@ -16,6 +16,7 @@
 package com.github.pockethub.android.ui.issue;
 
 import android.app.Activity;
+import android.support.annotation.NonNull;
 
 import com.github.pockethub.android.rx.AutoDisposeUtils;
 import com.github.pockethub.android.rx.RxProgress;
@@ -29,7 +30,6 @@ import com.github.pockethub.android.core.issue.IssueStore;
 import com.github.pockethub.android.ui.BaseActivity;
 import com.meisolsson.githubsdk.model.request.issue.IssueRequest;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
 import java.util.ArrayList;
@@ -96,7 +96,7 @@ public class EditLabelsTask {
      * @param labels
      * @return this task
      */
-    public EditLabelsTask edit(@Nonnull List<Label> labels) {
+    public EditLabelsTask edit(@NonNull List<Label> labels) {
         List<String> labelNames = new ArrayList<>();
         for (Label label : labels) {
             labelNames.add(label.name());

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.21'
+    ext.kotlin_version = '1.2.30'
     repositories {
         jcenter()
         google()
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     }
 }
 


### PR DESCRIPTION
I'm not totally sure why `javax.annotation.Nonnull` can't be found but converting to the Android platform NonNull annotation fixed it. Using the same nullability annotation is probably a good thing anyway.