### PR TITLE
Make Target drawable methods nullable as per the Picasso Javadoc

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/util/AvatarLoader.kt
+++ b/app/src/main/java/com/github/pockethub/android/util/AvatarLoader.kt
@@ -187,12 +187,16 @@ class AvatarLoader @Inject constructor(context: Context) {
             actionBar.setLogo(InsetDrawable(drawable, 0, 0, insetPx, 0))
         }
 
-        override fun onBitmapFailed(errorDrawable: Drawable) {
-            actionBar.setLogo(errorDrawable)
+        override fun onBitmapFailed(errorDrawable: Drawable?) {
+            if (errorDrawable != null) {
+                actionBar.setLogo(errorDrawable)
+            }
         }
 
-        override fun onPrepareLoad(placeHolderDrawable: Drawable) {
-            actionBar.setLogo(placeHolderDrawable)
+        override fun onPrepareLoad(placeHolderDrawable: Drawable?) {
+            if (placeHolderDrawable != null) {
+                actionBar.setLogo(placeHolderDrawable)
+            }
         }
     }
 


### PR DESCRIPTION
Going to a repository page crashes the app and this fixes it.

Picasso hadn't added `@nullable` annotations to their Target methods, so Kotlin crashes the app as `null` is being passed to a method which requires non nullability. I've sent a PR to Picasso in attempt to fix this issue for future uses of `Picasso#Target` (square/picasso#1825).