### PR TITLE
Move Groupie adapter setup to onCreate

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.java
@@ -19,6 +19,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -106,18 +107,16 @@ public class RepositoryCodeFragment extends BaseFragment implements OnItemClickL
     private RefDialog dialog;
 
     @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        Activity activity = (Activity) context;
-        repository = activity.getIntent().getParcelableExtra(EXTRA_REPOSITORY);
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        adapter.add(mainSection);
+        adapter.setOnItemClickListener(this);
+        repository = getActivity().getIntent().getParcelableExtra(EXTRA_REPOSITORY);
     }
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-
-        adapter.add(mainSection);
-        adapter.setOnItemClickListener(this);
 
         if (tree == null || folder == null) {
             refreshTree(null);

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareListFragment.java
@@ -112,19 +112,14 @@ public class CommitCompareListFragment extends BaseFragment implements OnItemCli
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        diffStyler = new DiffStyler(getResources());
-        compareCommits();
-    }
-
-    @Override
-    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
         mainSection.add(commitsSection);
         mainSection.add(filesSection);
         adapter.add(mainSection);
 
         adapter.setOnItemClickListener(this);
+
+        diffStyler = new DiffStyler(getResources());
+        compareCommits();
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitDiffListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitDiffListFragment.java
@@ -133,11 +133,6 @@ public class CommitDiffListFragment extends BaseFragment implements OnItemClickL
         Bundle args = getArguments();
         base = args.getString(EXTRA_BASE);
         repository = args.getParcelable(EXTRA_REPOSITORY);
-    }
-
-    @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
 
         mainSection.add(commitSection);
         mainSection.add(filesSection);
@@ -145,7 +140,11 @@ public class CommitDiffListFragment extends BaseFragment implements OnItemClickL
 
         adapter.add(mainSection);
         adapter.setOnItemClickListener(this);
+    }
 
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
         commit = store.getCommit(repository, base);
 
         if (files == null

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.java
@@ -133,6 +133,12 @@ public class GistFragment extends BaseFragment implements OnItemClickListener, D
         super.onCreate(savedInstanceState);
         gistId = getArguments().getString(EXTRA_GIST_ID);
         gist = store.getGist(gistId);
+
+        mainSection.add(filesSection);
+        mainSection.add(commentsSection);
+        adapter.add(mainSection);
+
+        adapter.setOnItemClickListener(this);
     }
 
     @Override
@@ -156,12 +162,6 @@ public class GistFragment extends BaseFragment implements OnItemClickListener, D
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        mainSection.add(filesSection);
-        mainSection.add(commentsSection);
-        adapter.add(mainSection);
-
-        adapter.setOnItemClickListener(this);
-
         if (gist != null) {
             updateHeader(gist);
             updateFiles(gist);

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueFragment.java
@@ -186,6 +186,8 @@ public class IssueFragment extends BaseFragment
         labelsTask = labelsTaskFactory.create(dialogActivity, repositoryId, issueNumber, createObserver());
         assigneeTask = assigneeTaskFactory.create(dialogActivity, repositoryId, issueNumber, createObserver());
         stateTask = stateTaskFactory.create(dialogActivity, repositoryId, issueNumber, createObserver());
+
+        adapter.add(mainSection);
     }
 
     private Consumer<Issue> createObserver() {
@@ -199,9 +201,6 @@ public class IssueFragment extends BaseFragment
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         issue = store.getIssue(repositoryId, issueNumber);
-
-        adapter.add(mainSection);
-
         if (issue == null || (issue.comments() > 0 && items == null)) {
             mainSection.setFooter(new LoadingItem(R.string.loading_comments));
         }


### PR DESCRIPTION
The app would crash if at any point a fragment was re-added to an activity. Since groupie would get the same items added and refuse them. The bug can be tested by going to a repository in the app and swiping over to issues and then back to code.