### PR TITLE
Setting elevation to 0 for action bar explicitly is unnecessary

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/TabPagerActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/TabPagerActivity.java
@@ -153,8 +153,6 @@ public abstract class TabPagerActivity<V extends PagerAdapter & FragmentProvider
     protected void onPostCreate(@Nullable Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
 
-        // On Lollipop, the action bar shadow is provided by default, so have to remove it explicitly
-        getSupportActionBar().setElevation(0);
         pager.addOnPageChangeListener(this);
     }
 


### PR DESCRIPTION
Related to #1195.