### PR TITLE
Show full path in repository code navigation

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.kt
@@ -30,7 +30,6 @@ import butterknife.BindView
 import com.github.pockethub.android.Intents.EXTRA_REPOSITORY
 import com.github.pockethub.android.R
 import com.github.pockethub.android.RequestCodes.REF_UPDATE
-import com.github.pockethub.android.util.android.text.url
 import com.github.pockethub.android.core.code.FullTree
 import com.github.pockethub.android.core.code.FullTree.Folder
 import com.github.pockethub.android.core.code.RefreshTreeTask
@@ -46,6 +45,7 @@ import com.github.pockethub.android.ui.ref.BranchFileViewActivity
 import com.github.pockethub.android.ui.ref.RefDialog
 import com.github.pockethub.android.ui.ref.RefDialogFragment
 import com.github.pockethub.android.util.ToastUtils
+import com.github.pockethub.android.util.android.text.url
 import com.meisolsson.githubsdk.model.Repository
 import com.meisolsson.githubsdk.model.git.GitReference
 import com.xwray.groupie.*
@@ -245,6 +245,18 @@ class RepositoryCodeFragment : BaseFragment(), OnItemClickListener, DialogResult
             val textLightColor = resources.getColor(R.color.text_light)
             val segments = folder.entry.path()!!.split("/")
             val text = buildSpannedString {
+                bold {
+                    url(repository!!.name()!!, onClick = {
+                        setFolder(tree, tree.root)
+                    }) {
+                        append(repository!!.name()!!)
+                    }
+                }
+                append(' ')
+                color(textLightColor) {
+                    append('/')
+                }
+                append(' ')
                 for (i in 0 until segments.size - 1) {
                     url(segments[i], onClick = {
                         var clicked: Folder? = folder

--- a/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.kt
@@ -79,8 +79,6 @@ class RepositoryCodeFragment : BaseFragment(), OnItemClickListener, DialogResult
 
     private var tree: FullTree? = null
 
-    private var pathShowing: Boolean = false
-
     private var folder: Folder? = null
 
     private var repository: Repository? = null
@@ -213,9 +211,7 @@ class RepositoryCodeFragment : BaseFragment(), OnItemClickListener, DialogResult
 
         branchFooterView.setOnClickListener { _ -> switchBranches() }
 
-        if (pathShowing) {
-            mainSection.setHeader(PathHeaderItem(""))
-        }
+        mainSection.setHeader(PathHeaderItem(""))
     }
 
     /**
@@ -273,13 +269,9 @@ class RepositoryCodeFragment : BaseFragment(), OnItemClickListener, DialogResult
                 }
             }
 
-            if (!pathShowing) {
-                mainSection.setHeader(PathHeaderItem(text))
-                pathShowing = true
-            }
-        } else if (pathShowing) {
+            mainSection.setHeader(PathHeaderItem(text))
+        } else {
             mainSection.removeHeader()
-            pathShowing = false
         }
 
 

--- a/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.kt
@@ -279,6 +279,11 @@ class RepositoryCodeFragment : BaseFragment(), OnItemClickListener, DialogResult
                 bold {
                     append(segments[segments.size - 1])
                 }
+                append(' ')
+                color(textLightColor) {
+                    append('/')
+                }
+                append(' ')
             }
 
             mainSection.setHeader(PathHeaderItem(text))

--- a/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.kt
@@ -250,7 +250,7 @@ class RepositoryCodeFragment : BaseFragment(), OnItemClickListener, DialogResult
             val segments = folder.entry.path()!!.split("/")
             val text = buildSpannedString {
                 for (i in 0 until segments.size - 1) {
-                    url(segments[i]) {
+                    url(segments[i], onClick = {
                         var clicked: Folder? = folder
                         for (i1 in i until segments.size - 1) {
                             clicked = clicked!!.parent
@@ -259,6 +259,8 @@ class RepositoryCodeFragment : BaseFragment(), OnItemClickListener, DialogResult
                             }
                         }
                         setFolder(tree, clicked!!)
+                    }) {
+                        append(segments[i])
                     }
                     append(' ')
                     color(textLightColor) {

--- a/app/src/main/java/com/github/pockethub/android/util/android/text/SpannableStringBuilder.kt
+++ b/app/src/main/java/com/github/pockethub/android/util/android/text/SpannableStringBuilder.kt
@@ -1,7 +1,6 @@
 package com.github.pockethub.android.util.android.text
 
 import android.text.SpannableStringBuilder
-import android.text.Spanned
 import android.text.style.TypefaceSpan
 import android.text.style.URLSpan
 import android.view.View
@@ -13,13 +12,15 @@ fun SpannableStringBuilder.monospace(builderAction: SpannableStringBuilder.() ->
     inSpans(TypefaceSpan("monospace"), builderAction = builderAction)
 }
 
-fun SpannableStringBuilder.url(text: String, listener: (View) -> Unit) {
-    setSpan(object : URLSpan(text) {
-        override fun onClick(widget: View) {
-            listener(widget)
-        }
-    }, length, length + text.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
-}
+fun SpannableStringBuilder.url(
+        url: String,
+        onClick: (View) -> Unit,
+        builderAction: SpannableStringBuilder.() -> Unit
+) = inSpans(object : URLSpan(url) {
+    override fun onClick(widget: View) {
+        onClick(widget)
+    }
+}, builderAction = builderAction)
 
 fun SpannableStringBuilder.append(date: Date) {
     val time = TimeUtils.getRelativeTime(date)


### PR DESCRIPTION
This fixes the repository code navigation. I used the same format as the GitHub desktop website, i.e. the root folder is the project name in bold, and there is a trailing forward slash.

![screenshot_20180323-133452](https://user-images.githubusercontent.com/6900601/37831941-0a6d06fc-2e9f-11e8-991c-2b5d944c5065.png)
