### PR TITLE
Remove redundant padding on file items

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/code/RepositoryCodeFragment.kt
@@ -281,16 +281,14 @@ class RepositoryCodeFragment : BaseFragment(), OnItemClickListener, DialogResult
         }
 
 
-        val indented = folder.entry != null
-
         val items = mutableListOf<Item<*>>()
 
         for (folder1 in folder.folders.values) {
-            items.add(FolderItem(activity!!, folder1, indented))
+            items.add(FolderItem(folder1))
         }
 
         for (blob in folder.files.values) {
-            items.add(BlobItem(activity!!, blob, indented))
+            items.add(BlobItem(activity!!, blob))
         }
 
         mainSection.update(items)

--- a/app/src/main/java/com/github/pockethub/android/ui/item/code/BlobItem.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/item/code/BlobItem.kt
@@ -10,28 +10,13 @@ import kotlinx.android.synthetic.main.blob_item.*
 
 class BlobItem(
         private val context: Context,
-        val file: FullTree.Entry,
-        private val indented: Boolean
+        val file: FullTree.Entry
 ) : Item(file.entry.sha()!!.hashCode().toLong()) {
-
-    private val indentedPaddingLeft =
-            context.resources.getDimensionPixelSize(R.dimen.blob_indentation)
 
     override fun getLayout() = R.layout.blob_item
 
     override fun bind(holder: ViewHolder, position: Int) {
         holder.tv_file.text = file.name
         holder.tv_size.text = Formatter.formatFileSize(context, file.entry.size()!!.toLong())
-
-        val paddingLeft = holder.root.paddingLeft
-        val paddingRight = holder.root.paddingRight
-        val paddingTop = holder.root.paddingTop
-        val paddingBottom = holder.root.paddingBottom
-
-        if (indented) {
-            holder.root.setPadding(indentedPaddingLeft, paddingTop, paddingRight, paddingBottom)
-        } else {
-            holder.root.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom)
-        }
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/item/code/FolderItem.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/item/code/FolderItem.kt
@@ -1,6 +1,5 @@
 package com.github.pockethub.android.ui.item.code
 
-import android.content.Context
 import com.github.pockethub.android.R
 import com.github.pockethub.android.core.code.FullTree
 import com.github.pockethub.android.core.commit.CommitUtils
@@ -8,14 +7,7 @@ import com.xwray.groupie.kotlinandroidextensions.Item
 import com.xwray.groupie.kotlinandroidextensions.ViewHolder
 import kotlinx.android.synthetic.main.folder_item.*
 
-class FolderItem(
-        context: Context,
-        val folder: FullTree.Folder,
-        private val indented: Boolean
-) : Item(folder.entry.sha()!!.hashCode().toLong()) {
-
-    private val indentedPaddingLeft =
-            context.resources.getDimensionPixelSize(R.dimen.folder_indentation)
+class FolderItem(val folder: FullTree.Folder) : Item(folder.entry.sha()!!.hashCode().toLong()) {
 
     override fun getLayout() = R.layout.folder_item
 
@@ -23,16 +15,5 @@ class FolderItem(
         holder.tv_folder.text = CommitUtils.getName(folder.name)
         holder.tv_folders.text = folder.folders.size.toString()
         holder.tv_files.text = folder.files.size.toString()
-
-        val paddingLeft = holder.root.paddingLeft
-        val paddingRight = holder.root.paddingRight
-        val paddingTop = holder.root.paddingTop
-        val paddingBottom = holder.root.paddingBottom
-
-        if (indented) {
-            holder.root.setPadding(indentedPaddingLeft, paddingTop, paddingRight, paddingBottom)
-        } else {
-            holder.root.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom)
-        }
     }
 }


### PR DESCRIPTION
It seems that the indentation on file items is unnecessary. I don't see the relevance of it but if there is please say. I thought it'd be easier to create a PR showing the code to get rid of instead of trying to link it in an issue.