### PR TITLE
Fix delete events text styling in news feed

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/item/news/DeleteEventItem.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/item/news/DeleteEventItem.kt
@@ -17,7 +17,7 @@ class DeleteEventItem(
     override fun bind(holder: ViewHolder, position: Int) {
         super.bind(holder, position)
         holder.tv_event_icon.text = OcticonTextView.ICON_DELETE
-        holder.tv_event_icon.text = buildSpannedString {
+        holder.tv_event.text = buildSpannedString {
             boldActor(this, gitHubEvent)
             val payload = gitHubEvent.payload() as DeletePayload?
             append(" deleted ${payload?.refType()?.name?.toLowerCase()} ${payload?.ref()} at ")


### PR DESCRIPTION
|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/6900601/37992946-0401b8f8-3205-11e8-8580-c20852f1dd57.png)|![after](https://user-images.githubusercontent.com/6900601/37992956-08cb112c-3205-11e8-9ab5-93f95d17e538.png)|

