### PR TITLE
Fix new search showing old results

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/search/SearchActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/search/SearchActivity.java
@@ -142,8 +142,8 @@ public class SearchActivity extends TabPagerActivity<SearchPagerAdapter> {
             repoFragment.setListShown(false);
             userFragment.setListShown(false);
 
-            repoFragment.refresh();
-            userFragment.refresh();
+            repoFragment.forceRefresh();
+            userFragment.forceRefresh();
         }
     }
 
@@ -157,9 +157,9 @@ public class SearchActivity extends TabPagerActivity<SearchPagerAdapter> {
         if (repoFragment == null || userFragment == null) {
             FragmentManager fm = getSupportFragmentManager();
             repoFragment = (SearchRepositoryListFragment) fm.findFragmentByTag(
-                "android:switcher:" + pager.getId() + ":" + 0);
+                    "android:switcher:" + pager.getId() + ":" + 0);
             userFragment = (SearchUserListFragment) fm.findFragmentByTag(
-                "android:switcher:" + pager.getId() + ":" + 1);
+                    "android:switcher:" + pager.getId() + ":" + 1);
         }
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/search/SearchRepositoryListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/search/SearchRepositoryListFragment.java
@@ -38,6 +38,7 @@ import com.meisolsson.githubsdk.service.search.SearchService;
 import com.xwray.groupie.Item;
 
 import java.text.MessageFormat;
+import java.util.List;
 
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -90,9 +91,15 @@ public class SearchRepositoryListFragment extends PagedItemFragment<Repository> 
     }
 
     @Override
+    public void forceRefresh(){
+        start();
+        super.forceRefresh();
+    }
+
+    @Override
     public void refresh() {
         start();
-        super.refresh();
+        super.refresh(true);
     }
 
     private void start() {
@@ -147,6 +154,12 @@ public class SearchRepositoryListFragment extends PagedItemFragment<Repository> 
                 });
 
         return true;
+    }
+
+    @Override
+    protected void onDataLoaded(List<Item> newItems) {
+        items.clear();
+        super.onDataLoaded(newItems);
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/search/SearchRepositoryListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/search/SearchRepositoryListFragment.java
@@ -99,7 +99,7 @@ public class SearchRepositoryListFragment extends PagedItemFragment<Repository> 
     @Override
     public void refresh() {
         start();
-        super.refresh(true);
+        super.refresh();
     }
 
     private void start() {
@@ -154,12 +154,6 @@ public class SearchRepositoryListFragment extends PagedItemFragment<Repository> 
                 });
 
         return true;
-    }
-
-    @Override
-    protected void onDataLoaded(List<Item> newItems) {
-        items.clear();
-        super.onDataLoaded(newItems);
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/search/SearchUserListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/search/SearchUserListFragment.java
@@ -34,6 +34,8 @@ import com.meisolsson.githubsdk.service.search.SearchService;
 import com.meisolsson.githubsdk.service.users.UserService;
 import com.xwray.groupie.Item;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
 import io.reactivex.Single;
@@ -91,10 +93,21 @@ public class SearchUserListFragment extends PagedItemFragment<User> {
     }
 
     @Override
+    public void forceRefresh(){
+        query = getStringExtra(QUERY);
+        super.forceRefresh();
+    }
+    @Override
     public void refresh() {
         query = getStringExtra(QUERY);
 
-        super.refresh();
+        super.refresh(true);
+    }
+
+    @Override
+    protected void onDataLoaded(List<Item> newItems) {
+        items.clear();
+        super.onDataLoaded(newItems);
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/search/SearchUserListFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/search/SearchUserListFragment.java
@@ -20,21 +20,19 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.view.View;
 
+import com.github.pockethub.android.R;
 import com.github.pockethub.android.rx.AutoDisposeUtils;
+import com.github.pockethub.android.ui.PagedItemFragment;
 import com.github.pockethub.android.ui.item.UserItem;
+import com.github.pockethub.android.ui.user.UserViewActivity;
+import com.github.pockethub.android.util.AvatarLoader;
 import com.meisolsson.githubsdk.core.ServiceGenerator;
 import com.meisolsson.githubsdk.model.Page;
 import com.meisolsson.githubsdk.model.SearchPage;
 import com.meisolsson.githubsdk.model.User;
-import com.github.pockethub.android.R;
-import com.github.pockethub.android.ui.PagedItemFragment;
-import com.github.pockethub.android.ui.user.UserViewActivity;
-import com.github.pockethub.android.util.AvatarLoader;
 import com.meisolsson.githubsdk.service.search.SearchService;
 import com.meisolsson.githubsdk.service.users.UserService;
 import com.xwray.groupie.Item;
-
-import java.util.List;
 
 import javax.inject.Inject;
 
@@ -97,17 +95,11 @@ public class SearchUserListFragment extends PagedItemFragment<User> {
         query = getStringExtra(QUERY);
         super.forceRefresh();
     }
+
     @Override
     public void refresh() {
         query = getStringExtra(QUERY);
-
-        super.refresh(true);
-    }
-
-    @Override
-    protected void onDataLoaded(List<Item> newItems) {
-        items.clear();
-        super.onDataLoaded(newItems);
+        super.refresh();
     }
 
     @Override


### PR DESCRIPTION
On search results view, if you start a new search by entering a new
query, page will reload and but will show the old results.
Fixing this by forcing refresh and clearing old results.