### PR TITLE
App crash after device rotation #1222

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -357,7 +357,8 @@
         </activity>
 
         <activity android:name=".accounts.LoginWebViewActivity"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTop"
+            android:configChanges="orientation|keyboardHidden|screenSize" />
 
         <service
             android:name=".sync.SyncAdapterService"


### PR DESCRIPTION
related to #1222 and #1220 

Crashes happened when the user rotates the device multiple times before the webview finishes it's request to github for the login page. This caused the UI to not update correctly.

Fix: added config changes to AndroidManifest.xml in LoginWebViewActivity tag to prevent this activity from being recreated on orientation change and making multiple web calls.