### PR TITLE
Fixes #1253 Allow the issue creator to select assignee

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/issue/AssigneeDialogFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/AssigneeDialogFragment.java
@@ -79,7 +79,7 @@ public class AssigneeDialogFragment extends SingleChoiceDialogFragment {
         for (User user : getChoices()) {
             adapter.add(new AssigneeDialogItem(avatars, user, selected));
         }
-
+        adapter.setOnItemClickListener(this);
 
         return createDialogBuilder()
                 .adapter(adapter, null)


### PR DESCRIPTION
Adds a missing `onItemClickListener` in the issue creation dialog.