### PR TITLE
Allow to star/unstar any gist

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFragment.kt
@@ -205,18 +205,14 @@ class GistFragment : BaseFragment(), OnItemClickListener, DialogResultListener {
 
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
-        val owner = isOwner
-        if (!owner) {
-            menu.removeItem(R.id.m_delete)
-            val starItem = menu.findItem(R.id.m_star)
-            starItem.isEnabled = loadFinished && !owner
-            if (starred) {
-                starItem.setTitle(R.string.unstar)
-            } else {
-                starItem.setTitle(R.string.star)
-            }
+        menu.findItem(R.id.m_delete).isVisible = isOwner
+
+        val starItem = menu.findItem(R.id.m_star)
+        starItem.isEnabled = loadFinished
+        if (starred) {
+            starItem.setTitle(R.string.unstar)
         } else {
-            menu.removeItem(R.id.m_star)
+            starItem.setTitle(R.string.star)
         }
     }
 


### PR DESCRIPTION
Not sure why this was the way it was but earlier we could only star/unstar other users gists. Now we can do it to any gist.

We also wrongly removed the delete option when we probably should just hide it.

Fixes #1259