### PR TITLE
Support filtering the repositories page list

### DIFF
--- a/app/res/layout/item_filter_list.xml
+++ b/app/res/layout/item_filter_list.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2012 GitHub Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" >
+
+    <EditText
+        android:id="@+id/et_filter"
+        style="@style/EditText"
+        android:layout_width="match_parent"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_margin="2dp"
+        android:hint="@string/find_a_repository"
+        android:inputType="text|textNoSuggestions"
+        android:padding="6dp"
+        android:singleLine="true"
+        android:visibility="gone" />
+
+    <ListView
+        android:id="@android:id/list"
+        style="@style/ListView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/et_filter"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@android:id/empty"
+        style="@style/ListSubtitleText"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:visibility="gone" />
+
+    <ProgressBar
+        android:id="@+id/pb_loading"
+        style="@style/Spinner"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:layout_centerInParent="true" />
+
+</RelativeLayout>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -207,5 +207,6 @@
     <string name="authenticator_conflict_title">App Conflict</string>
     <string name="authenticator_conflict_message">Another installed app is already configured for GitHub authentication.\n\nYou must remove the other app from the Accounts &amp; sync settings and uninstall it before the GitHub app can be used.</string>
     <string name="opening_repository">"Opening {0}…"</string>
+    <string name="find_a_repository">Find a Repository…</string>
 
 </resources>

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -47,7 +47,12 @@
         <item name="android:divider">@null</item>
     </style>
 
-    <style name="EditText">
+    <style name="Global">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="EditText" parent="Global">
         <item name="android:textColor">@color/text</item>
         <item name="android:textCursorDrawable">@drawable/edit_text_cursor</item>
         <item name="android:textSize">14sp</item>
@@ -125,8 +130,7 @@
         <item name="android:singleLine">true</item>
     </style>
 
-    <style name="ListTitleText" parent="TitleText">
-    </style>
+    <style name="ListTitleText" parent="TitleText"></style>
 
     <style name="SubtitleText">
         <item name="android:textSize">14sp</item>
@@ -135,8 +139,7 @@
         <item name="android:layout_width">wrap_content</item>
     </style>
 
-    <style name="ListSubtitleText" parent="SubtitleText">
-    </style>
+    <style name="ListSubtitleText" parent="SubtitleText"></style>
 
     <style name="ListNumericSubtitleText" parent="ListSubtitleText">
         <item name="android:singleLine">true</item>

--- a/app/src/main/java/com/github/mobile/ui/ItemFilter.java
+++ b/app/src/main/java/com/github/mobile/ui/ItemFilter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2012 GitHub Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mobile.ui;
+
+import static java.util.Locale.US;
+import android.text.TextUtils;
+import android.widget.Filter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Item filter
+ *
+ * @param <V>
+ */
+public abstract class ItemFilter<V> extends Filter {
+
+    private final ItemListAdapter<V, ?> adapter;
+
+    /**
+     * Create item filter
+     *
+     * @param adapter
+     */
+    public ItemFilter(ItemListAdapter<V, ?> adapter) {
+        this.adapter = adapter;
+    }
+
+    /**
+     * Does the value contain the filter text?
+     *
+     * @param filter
+     * @param value
+     * @return true if contains, false otherwise
+     */
+    protected boolean contains(final String filter, final String value) {
+        if (TextUtils.isEmpty(value))
+            return false;
+
+        final int fLength = filter.length();
+        final int vLength = value.length();
+        if (fLength > vLength)
+            return false;
+
+        int fIndex = 0;
+        int vIndex = 0;
+        while (vIndex < vLength)
+            if (filter.charAt(fIndex) == Character.toUpperCase(value
+                    .charAt(vIndex))) {
+                vIndex++;
+                fIndex++;
+                if (fIndex == fLength)
+                    return true;
+            } else {
+                vIndex += fIndex + 1;
+                fIndex = 0;
+            }
+        return false;
+    }
+
+    /**
+     * Is item match for prefix?
+     *
+     * @param prefix
+     * @param upperCasePrefix
+     * @param item
+     * @return true if match, false otherwise
+     */
+    protected abstract boolean isMatch(CharSequence prefix,
+            String upperCasePrefix, V item);
+
+    @Override
+    protected FilterResults performFiltering(CharSequence prefix) {
+        FilterResults results = new FilterResults();
+        if (TextUtils.isEmpty(prefix))
+            return results;
+
+        final List<V> initial = adapter.getInitialItems();
+        String upperPrefix = prefix.toString().toUpperCase(US);
+        List<V> filtered = new ArrayList<V>();
+        for (V item : initial)
+            if (isMatch(prefix, upperPrefix, item))
+                filtered.add(item);
+
+        results.values = filtered;
+        results.count = filtered.size();
+        return results;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void publishResults(CharSequence constraint, FilterResults results) {
+        if (results.values != null)
+            adapter.setFilteredItems((List<V>) results.values);
+        else
+            adapter.setItems(adapter.getInitialItems());
+
+        if (results.count == 0)
+            adapter.notifyDataSetInvalidated();
+    }
+}

--- a/app/src/main/java/com/github/mobile/ui/ItemListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/ItemListAdapter.java
@@ -19,6 +19,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
+import android.widget.Filter;
+import android.widget.Filterable;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * List adapter for items of a specific type
@@ -27,13 +32,15 @@ import android.widget.BaseAdapter;
  * @param <V>
  */
 public abstract class ItemListAdapter<I, V extends ItemView> extends
-        BaseAdapter {
+        BaseAdapter implements Filterable {
 
     private final LayoutInflater inflater;
 
     private final int viewId;
 
-    private Object[] elements;
+    private List<I> items;
+
+    private List<I> initialItems;
 
     /**
      * Create empty adapter
@@ -50,16 +57,17 @@ public abstract class ItemListAdapter<I, V extends ItemView> extends
      *
      * @param viewId
      * @param inflater
-     * @param elements
+     * @param items
      */
     public ItemListAdapter(final int viewId, final LayoutInflater inflater,
-            final I[] elements) {
+            final List<I> items) {
         this.viewId = viewId;
         this.inflater = inflater;
-        if (elements != null)
-            this.elements = elements;
+        if (items != null)
+            this.items = items;
         else
-            this.elements = new Object[0];
+            this.items = Collections.emptyList();
+        this.initialItems = this.items;
     }
 
     @Override
@@ -68,37 +76,60 @@ public abstract class ItemListAdapter<I, V extends ItemView> extends
     }
 
     /**
+     * Get items being displayed
+     *
      * @return items
      */
-    @SuppressWarnings("unchecked")
-    protected I[] getItems() {
-        return (I[]) elements;
+    public List<I> getItems() {
+        return items;
     }
 
     public int getCount() {
-        return elements.length;
+        return items.size();
     }
 
-    @SuppressWarnings("unchecked")
     public I getItem(int position) {
-        return (I) elements[position];
+        return items.get(position);
     }
 
     public long getItemId(int position) {
-        return elements[position].hashCode();
+        return getItem(position).hashCode();
+    }
+
+    /**
+     * @return initialItems
+     */
+    protected List<I> getInitialItems() {
+        return initialItems;
     }
 
     /**
      * Set items
      *
      * @param items
-     * @return items
+     * @return this adapter
      */
-    public ItemListAdapter<I, V> setItems(final Object[] items) {
+    public ItemListAdapter<I, V> setItems(final List<I> items) {
         if (items != null)
-            elements = items;
+            this.items = items;
         else
-            elements = new Object[0];
+            this.items = Collections.emptyList();
+        initialItems = this.items;
+        notifyDataSetChanged();
+        return this;
+    }
+
+    /**
+     * Set filtered items to display
+     *
+     * @param items
+     * @return this adapter
+     */
+    public ItemListAdapter<I, V> setFilteredItems(final List<I> items) {
+        if (items != null)
+            this.items = items;
+        else
+            this.items = Collections.emptyList();
         notifyDataSetChanged();
         return this;
     }
@@ -120,6 +151,7 @@ public abstract class ItemListAdapter<I, V extends ItemView> extends
      */
     protected abstract V createView(View view);
 
+    @Override
     public View getView(final int position, View convertView,
             final ViewGroup parent) {
         @SuppressWarnings("unchecked")
@@ -131,5 +163,10 @@ public abstract class ItemListAdapter<I, V extends ItemView> extends
         }
         update(position, view, getItem(position));
         return convertView;
+    }
+
+    @Override
+    public Filter getFilter() {
+        return null;
     }
 }

--- a/app/src/main/java/com/github/mobile/ui/ItemListFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/ItemListFragment.java
@@ -215,7 +215,7 @@ public abstract class ItemListFragment<E> extends RoboSherlockFragment
         }
 
         this.items = items;
-        getListAdapter().getWrappedAdapter().setItems(items.toArray());
+        getListAdapter().getWrappedAdapter().setItems(items);
         showList();
     }
 

--- a/app/src/main/java/com/github/mobile/ui/NewsFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/NewsFragment.java
@@ -166,8 +166,8 @@ public abstract class NewsFragment extends PagedItemFragment<Event> {
     @Override
     protected ItemListAdapter<Event, ? extends ItemView> createAdapter(
             List<Event> items) {
-        return new NewsListAdapter(getActivity().getLayoutInflater(),
-                items.toArray(new Event[items.size()]), avatars);
+        return new NewsListAdapter(getActivity().getLayoutInflater(), items,
+                avatars);
     }
 
     @Override

--- a/app/src/main/java/com/github/mobile/ui/comment/CommentListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/comment/CommentListAdapter.java
@@ -24,6 +24,8 @@ import com.github.mobile.util.HttpImageGetter;
 import com.github.mobile.util.TimeUtils;
 import com.viewpagerindicator.R.layout;
 
+import java.util.List;
+
 import org.eclipse.egit.github.core.Comment;
 
 /**
@@ -44,7 +46,7 @@ public class CommentListAdapter extends
      * @param avatars
      * @param imageGetter
      */
-    public CommentListAdapter(LayoutInflater inflater, Comment[] elements,
+    public CommentListAdapter(LayoutInflater inflater, List<Comment> elements,
             AvatarLoader avatars, HttpImageGetter imageGetter) {
         super(layout.comment_item, inflater, elements);
 

--- a/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
@@ -354,8 +354,7 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
     }
 
     private void updateList(Gist gist, List<Comment> comments) {
-        adapter.getWrappedAdapter().setItems(
-                comments.toArray(new Comment[comments.size()]));
+        adapter.getWrappedAdapter().setItems(comments);
         adapter.removeHeader(loadingView);
 
         headerView.setVisibility(VISIBLE);

--- a/app/src/main/java/com/github/mobile/ui/gist/GistListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistListAdapter.java
@@ -26,6 +26,7 @@ import com.github.mobile.ui.StyledText;
 import com.github.mobile.util.AvatarLoader;
 
 import java.text.NumberFormat;
+import java.util.List;
 
 import org.eclipse.egit.github.core.Gist;
 import org.eclipse.egit.github.core.User;
@@ -46,7 +47,7 @@ public class GistListAdapter extends ItemListAdapter<Gist, GistView> {
      * @param elements
      */
     public GistListAdapter(AvatarLoader avatars, LayoutInflater inflater,
-            Gist[] elements) {
+            List<Gist> elements) {
         super(layout.gist_item, inflater, elements);
 
         this.avatars = avatars;

--- a/app/src/main/java/com/github/mobile/ui/gist/GistsFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistsFragment.java
@@ -112,6 +112,6 @@ public abstract class GistsFragment extends PagedItemFragment<Gist> {
     protected ItemListAdapter<Gist, ? extends ItemView> createAdapter(
             List<Gist> items) {
         return new GistListAdapter(avatars, getActivity().getLayoutInflater(),
-                items.toArray(new Gist[items.size()]));
+                items);
     }
 }

--- a/app/src/main/java/com/github/mobile/ui/gist/MyGistsFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/MyGistsFragment.java
@@ -67,7 +67,7 @@ public class MyGistsFragment extends GistsFragment {
     @Override
     protected ItemListAdapter<Gist, ? extends ItemView> createAdapter(
             List<Gist> items) {
-        return new GistListAdapter(avatars, getActivity()
-                .getLayoutInflater(), items.toArray(new Gist[items.size()]));
+        return new GistListAdapter(avatars, getActivity().getLayoutInflater(),
+                items);
     }
 }

--- a/app/src/main/java/com/github/mobile/ui/issue/AssigneeDialogFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/AssigneeDialogFragment.java
@@ -43,6 +43,7 @@ import com.viewpagerindicator.R.id;
 import com.viewpagerindicator.R.layout;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.egit.github.core.User;
 
@@ -75,7 +76,7 @@ public class AssigneeDialogFragment extends SingleChoiceDialogFragment {
 
         private final AvatarLoader loader;
 
-        public UserListAdapter(LayoutInflater inflater, User[] users,
+        public UserListAdapter(LayoutInflater inflater, List<User> users,
                 int selected, AvatarLoader loader) {
             super(layout.collaborator_item, inflater, users);
 
@@ -157,8 +158,8 @@ public class AssigneeDialogFragment extends SingleChoiceDialogFragment {
 
         ArrayList<User> choices = getChoices();
         int selected = arguments.getInt(ARG_SELECTED_CHOICE);
-        UserListAdapter adapter = new UserListAdapter(inflater,
-                choices.toArray(new User[choices.size()]), selected, loader);
+        UserListAdapter adapter = new UserListAdapter(inflater, choices,
+                selected, loader);
         view.setAdapter(adapter);
         if (selected >= 0)
             view.setSelection(selected);

--- a/app/src/main/java/com/github/mobile/ui/issue/DashboardIssueFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/DashboardIssueFragment.java
@@ -128,7 +128,6 @@ public class DashboardIssueFragment extends PagedItemFragment<RepositoryIssue> {
     protected ItemListAdapter<RepositoryIssue, ? extends ItemView> createAdapter(
             List<RepositoryIssue> items) {
         return new DashboardIssueListAdapter(avatars, getActivity()
-                .getLayoutInflater(), items.toArray(new RepositoryIssue[items
-                .size()]));
+                .getLayoutInflater(), items);
     }
 }

--- a/app/src/main/java/com/github/mobile/ui/issue/DashboardIssueListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/DashboardIssueListAdapter.java
@@ -23,6 +23,8 @@ import com.github.mobile.core.issue.IssueUtils;
 import com.github.mobile.util.AvatarLoader;
 import com.github.mobile.util.ViewUtils;
 
+import java.util.List;
+
 import org.eclipse.egit.github.core.RepositoryIssue;
 
 /**
@@ -39,7 +41,7 @@ public class DashboardIssueListAdapter extends
      * @param elements
      */
     public DashboardIssueListAdapter(AvatarLoader avatars,
-            LayoutInflater inflater, RepositoryIssue[] elements) {
+            LayoutInflater inflater, List<RepositoryIssue> elements) {
         super(layout.dashboard_issue_item, inflater, elements, avatars);
     }
 

--- a/app/src/main/java/com/github/mobile/ui/issue/FilterListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/FilterListAdapter.java
@@ -27,6 +27,7 @@ import com.github.mobile.ui.ItemListAdapter;
 import com.github.mobile.util.AvatarLoader;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.egit.github.core.Label;
 import org.eclipse.egit.github.core.Milestone;
@@ -47,8 +48,8 @@ public class FilterListAdapter extends
      * @param elements
      * @param avatars
      */
-    public FilterListAdapter(LayoutInflater inflater, IssueFilter[] elements,
-            AvatarLoader avatars) {
+    public FilterListAdapter(LayoutInflater inflater,
+            List<IssueFilter> elements, AvatarLoader avatars) {
         super(layout.issues_filter_item, inflater, elements);
 
         this.avatars = avatars;

--- a/app/src/main/java/com/github/mobile/ui/issue/FilterListFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/FilterListFragment.java
@@ -75,8 +75,8 @@ public class FilterListFragment extends ItemListFragment<IssueFilter> implements
     @Override
     protected ItemListAdapter<IssueFilter, ? extends ItemView> createAdapter(
             List<IssueFilter> items) {
-        return new FilterListAdapter(getActivity().getLayoutInflater(),
-                items.toArray(new IssueFilter[items.size()]), avatars);
+        return new FilterListAdapter(getActivity().getLayoutInflater(), items,
+                avatars);
     }
 
     @Override

--- a/app/src/main/java/com/github/mobile/ui/issue/IssueFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/IssueFragment.java
@@ -41,10 +41,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
-import android.widget.HeaderViewListAdapter;
 import android.widget.ImageView;
 import android.widget.LinearLayout.LayoutParams;
-import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -432,27 +430,11 @@ public class IssueFragment extends DialogFragment {
     }
 
     private void updateList(Issue issue, List<Comment> comments) {
-        adapter.getWrappedAdapter().setItems(
-                comments.toArray(new Comment[comments.size()]));
+        adapter.getWrappedAdapter().setItems(comments);
         adapter.removeHeader(loadingView);
 
         headerView.setVisibility(VISIBLE);
         updateHeader(issue);
-
-        CommentListAdapter adapter = getRootAdapter();
-        if (adapter != null)
-            adapter.setItems(comments.toArray(new Comment[comments.size()]));
-    }
-
-    private CommentListAdapter getRootAdapter() {
-        ListAdapter adapter = list.getAdapter();
-        if (adapter == null)
-            return null;
-        adapter = ((HeaderViewListAdapter) adapter).getWrappedAdapter();
-        if (adapter instanceof CommentListAdapter)
-            return (CommentListAdapter) adapter;
-        else
-            return null;
     }
 
     @Override

--- a/app/src/main/java/com/github/mobile/ui/issue/IssueListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/IssueListAdapter.java
@@ -74,15 +74,15 @@ public abstract class IssueListAdapter<I, V extends ItemView> extends
      * @param elements
      * @param avatars
      */
-    public IssueListAdapter(int viewId, LayoutInflater inflater, I[] elements,
-            AvatarLoader avatars) {
+    public IssueListAdapter(int viewId, LayoutInflater inflater,
+            List<I> elements, AvatarLoader avatars) {
         super(viewId, inflater, elements);
 
         this.avatars = avatars;
         this.numberView = (TextView) inflater.inflate(viewId, null)
                 .findViewById(id.tv_issue_number);
 
-        if (elements != null && elements.length > 0)
+        if (elements != null && elements.size() > 0)
             computeNumberWidth(elements);
     }
 
@@ -94,18 +94,17 @@ public abstract class IssueListAdapter<I, V extends ItemView> extends
      */
     protected abstract int getNumber(I issue);
 
-    @SuppressWarnings("unchecked")
-    private void computeNumberWidth(final Object[] items) {
-        int[] numbers = new int[items.length];
+    private void computeNumberWidth(final List<I> items) {
+        int[] numbers = new int[items.size()];
         for (int i = 0; i < numbers.length; i++)
-            numbers[i] = getNumber((I) items[i]);
+            numbers[i] = getNumber(items.get(i));
         int digits = Math.max(TypefaceUtils.getMaxDigits(numbers), 4);
         numberWidth = TypefaceUtils.getWidth(numberView, digits)
                 + numberView.getPaddingLeft() + numberView.getPaddingRight();
     }
 
     @Override
-    public ItemListAdapter<I, V> setItems(final Object[] items) {
+    public ItemListAdapter<I, V> setItems(final List<I> items) {
         computeNumberWidth(items);
 
         return super.setItems(items);

--- a/app/src/main/java/com/github/mobile/ui/issue/IssuesFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/IssuesFragment.java
@@ -274,7 +274,6 @@ public class IssuesFragment extends PagedItemFragment<Issue> {
     protected ItemListAdapter<Issue, ? extends ItemView> createAdapter(
             List<Issue> items) {
         return new RepositoryIssueListAdapter(
-                getActivity().getLayoutInflater(),
-                items.toArray(new Issue[items.size()]), avatars);
+                getActivity().getLayoutInflater(), items, avatars);
     }
 }

--- a/app/src/main/java/com/github/mobile/ui/issue/LabelsDialogFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/LabelsDialogFragment.java
@@ -45,6 +45,7 @@ import com.viewpagerindicator.R.layout;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 import org.eclipse.egit.github.core.Label;
 
@@ -85,7 +86,7 @@ public class LabelsDialogFragment extends DialogFragmentHelper implements
 
         private final boolean[] selected;
 
-        public LabelListAdapter(LayoutInflater inflater, Label[] labels,
+        public LabelListAdapter(LayoutInflater inflater, List<Label> labels,
                 boolean[] selected) {
             super(layout.label_item, inflater, labels);
 
@@ -160,8 +161,8 @@ public class LabelsDialogFragment extends DialogFragmentHelper implements
         LayoutInflater inflater = activity.getLayoutInflater();
         ListView view = (ListView) inflater.inflate(layout.dialog_list_view,
                 null);
-        LabelListAdapter adapter = new LabelListAdapter(inflater,
-                choices.toArray(new Label[choices.size()]), selectedChoices);
+        LabelListAdapter adapter = new LabelListAdapter(inflater, choices,
+                selectedChoices);
         view.setAdapter(adapter);
         view.setOnItemClickListener(adapter);
 

--- a/app/src/main/java/com/github/mobile/ui/issue/MilestoneDialogFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/MilestoneDialogFragment.java
@@ -43,6 +43,7 @@ import com.viewpagerindicator.R.id;
 import com.viewpagerindicator.R.layout;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.egit.github.core.Milestone;
 
@@ -75,7 +76,7 @@ public class MilestoneDialogFragment extends SingleChoiceDialogFragment {
         private final int selected;
 
         public MilestoneListAdapter(LayoutInflater inflater,
-                Milestone[] milestones, int selected) {
+                List<Milestone> milestones, int selected) {
             super(layout.milestone_item, inflater, milestones);
 
             this.selected = selected;
@@ -158,7 +159,7 @@ public class MilestoneDialogFragment extends SingleChoiceDialogFragment {
         ArrayList<Milestone> choices = getChoices();
         int selected = arguments.getInt(ARG_SELECTED_CHOICE);
         MilestoneListAdapter adapter = new MilestoneListAdapter(inflater,
-                choices.toArray(new Milestone[choices.size()]), selected);
+                choices, selected);
         view.setAdapter(adapter);
         if (selected >= 0)
             view.setSelection(selected);

--- a/app/src/main/java/com/github/mobile/ui/issue/RepositoryIssueListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/RepositoryIssueListAdapter.java
@@ -23,6 +23,8 @@ import com.github.mobile.util.AvatarLoader;
 import com.github.mobile.util.ViewUtils;
 import com.viewpagerindicator.R.layout;
 
+import java.util.List;
+
 import org.eclipse.egit.github.core.Issue;
 
 /**
@@ -37,7 +39,7 @@ public class RepositoryIssueListAdapter extends
      * @param avatars
      */
     public RepositoryIssueListAdapter(LayoutInflater inflater,
-            Issue[] elements, AvatarLoader avatars) {
+            List<Issue> elements, AvatarLoader avatars) {
         super(layout.repo_issue_item, inflater, elements, avatars);
     }
 

--- a/app/src/main/java/com/github/mobile/ui/issue/SearchIssueListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/SearchIssueListAdapter.java
@@ -24,6 +24,8 @@ import com.github.mobile.util.AvatarLoader;
 import com.github.mobile.util.ViewUtils;
 import com.viewpagerindicator.R.layout;
 
+import java.util.List;
+
 import org.eclipse.egit.github.core.SearchIssue;
 import org.eclipse.egit.github.core.User;
 
@@ -39,7 +41,7 @@ public class SearchIssueListAdapter extends
      * @param avatars
      */
     public SearchIssueListAdapter(LayoutInflater inflater,
-            SearchIssue[] elements, AvatarLoader avatars) {
+            List<SearchIssue> elements, AvatarLoader avatars) {
         super(layout.repo_issue_item, inflater, elements, avatars);
     }
 

--- a/app/src/main/java/com/github/mobile/ui/issue/SearchIssueListFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/issue/SearchIssueListFragment.java
@@ -118,7 +118,7 @@ public class SearchIssueListFragment extends ItemListFragment<SearchIssue>
     protected ItemListAdapter<SearchIssue, ? extends ItemView> createAdapter(
             List<SearchIssue> items) {
         return new SearchIssueListAdapter(getActivity().getLayoutInflater(),
-                items.toArray(new SearchIssue[items.size()]), avatars);
+                items, avatars);
     }
 
     @Override

--- a/app/src/main/java/com/github/mobile/ui/repo/DefaultRepositoryListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/repo/DefaultRepositoryListAdapter.java
@@ -21,12 +21,14 @@ import android.view.LayoutInflater;
 import android.view.View;
 
 import com.actionbarsherlock.R.color;
+import com.github.mobile.ui.ItemFilter;
 import com.github.mobile.ui.StyledText;
 import com.github.mobile.util.ViewUtils;
 import com.viewpagerindicator.R.layout;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -46,6 +48,8 @@ public class DefaultRepositoryListAdapter extends
 
     private final Set<Long> noSeparators = new HashSet<Long>();
 
+    private ItemFilter<Repository> filter;
+
     /**
      * Create list adapter for repositories
      *
@@ -54,21 +58,10 @@ public class DefaultRepositoryListAdapter extends
      * @param account
      */
     public DefaultRepositoryListAdapter(LayoutInflater inflater,
-            Repository[] elements, AtomicReference<User> account) {
+            List<Repository> elements, AtomicReference<User> account) {
         super(layout.repo_item, inflater, elements);
 
         this.account = account;
-    }
-
-    /**
-     * Create list adapter for repositories
-     *
-     * @param inflater
-     * @param account
-     */
-    public DefaultRepositoryListAdapter(LayoutInflater inflater,
-            AtomicReference<User> account) {
-        this(inflater, null, account);
     }
 
     /**
@@ -144,5 +137,21 @@ public class DefaultRepositoryListAdapter extends
     @Override
     public long getItemId(final int position) {
         return getItem(position).getId();
+    }
+
+    @Override
+    public ItemFilter<Repository> getFilter() {
+        if (filter == null)
+            filter = new ItemFilter<Repository>(this) {
+
+                @Override
+                protected boolean isMatch(CharSequence prefix,
+                        String upperCasePrefix, Repository item) {
+                    return contains(upperCasePrefix, item.getName())
+                            || contains(upperCasePrefix, item.getOwner()
+                                    .getLogin());
+                }
+            };
+        return filter;
     }
 }

--- a/app/src/main/java/com/github/mobile/ui/repo/RepositoryListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/repo/RepositoryListAdapter.java
@@ -29,6 +29,7 @@ import com.github.mobile.ui.ItemListAdapter;
 import com.github.mobile.ui.ItemView;
 
 import java.text.NumberFormat;
+import java.util.List;
 
 /**
  * Adapter for a list of repositories
@@ -55,7 +56,7 @@ public abstract class RepositoryListAdapter<I, V extends ItemView> extends
      * @param elements
      */
     public RepositoryListAdapter(int viewId, LayoutInflater inflater,
-            I[] elements) {
+            List<I> elements) {
         super(viewId, inflater, elements);
     }
 

--- a/app/src/main/java/com/github/mobile/ui/repo/SearchRepositoryListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/repo/SearchRepositoryListAdapter.java
@@ -22,6 +22,8 @@ import android.view.View;
 import com.github.mobile.ui.StyledText;
 import com.viewpagerindicator.R.layout;
 
+import java.util.List;
+
 import org.eclipse.egit.github.core.SearchRepository;
 
 /**
@@ -37,18 +39,8 @@ public class SearchRepositoryListAdapter extends
      * @param elements
      */
     public SearchRepositoryListAdapter(LayoutInflater inflater,
-            SearchRepository[] elements) {
+            List<SearchRepository> elements) {
         super(layout.user_repo_item, inflater, elements);
-    }
-
-    /**
-     *
-     * Create list adapter for searched for repositories
-     *
-     * @param inflater
-     */
-    public SearchRepositoryListAdapter(LayoutInflater inflater) {
-        this(inflater, null);
     }
 
     @Override

--- a/app/src/main/java/com/github/mobile/ui/repo/SearchRepositoryListFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/repo/SearchRepositoryListFragment.java
@@ -106,7 +106,6 @@ public class SearchRepositoryListFragment extends
     protected ItemListAdapter<SearchRepository, ? extends ItemView> createAdapter(
             List<SearchRepository> items) {
         return new SearchRepositoryListAdapter(getActivity()
-                .getLayoutInflater(), items.toArray(new SearchRepository[items
-                .size()]));
+                .getLayoutInflater(), items);
     }
 }

--- a/app/src/main/java/com/github/mobile/ui/repo/UserRepositoryListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/repo/UserRepositoryListAdapter.java
@@ -22,6 +22,8 @@ import com.actionbarsherlock.R.color;
 import com.github.mobile.ui.StyledText;
 import com.viewpagerindicator.R.layout;
 
+import java.util.List;
+
 import org.eclipse.egit.github.core.Repository;
 import org.eclipse.egit.github.core.User;
 
@@ -41,20 +43,10 @@ public class UserRepositoryListAdapter extends
      * @param user
      */
     public UserRepositoryListAdapter(LayoutInflater inflater,
-            Repository[] elements, User user) {
+            List<Repository> elements, User user) {
         super(layout.user_repo_item, inflater, elements);
 
         login = user.getLogin();
-    }
-
-    /**
-     * Create list adapter for repositories
-     *
-     * @param inflater
-     * @param user
-     */
-    public UserRepositoryListAdapter(LayoutInflater inflater, User user) {
-        this(inflater, null, user);
     }
 
     @Override

--- a/app/src/main/java/com/github/mobile/ui/repo/UserRepositoryListFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/repo/UserRepositoryListFragment.java
@@ -84,7 +84,7 @@ public class UserRepositoryListFragment extends PagedItemFragment<Repository> {
     protected ItemListAdapter<Repository, ? extends ItemView> createAdapter(
             List<Repository> items) {
         return new UserRepositoryListAdapter(getActivity().getLayoutInflater(),
-                items.toArray(new Repository[items.size()]), user);
+                items, user);
     }
 
     @Override

--- a/app/src/main/java/com/github/mobile/ui/user/HomeDropdownListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/user/HomeDropdownListAdapter.java
@@ -76,7 +76,7 @@ public class HomeDropdownListAdapter extends BaseAdapter {
         private final AvatarLoader avatars;
 
         public OrgListAdapter(final int viewId, final LayoutInflater inflater,
-                final User[] elements, final AvatarLoader avatars) {
+                final List<User> elements, final AvatarLoader avatars) {
             super(viewId, inflater, elements);
 
             this.avatars = avatars;
@@ -120,12 +120,11 @@ public class HomeDropdownListAdapter extends BaseAdapter {
         this.context = context;
 
         LayoutInflater inflater = LayoutInflater.from(context);
-        User[] orgItems = orgs.toArray(new User[orgs.size()]);
 
-        listAdapter = new OrgListAdapter(layout.org_item, inflater, orgItems,
+        listAdapter = new OrgListAdapter(layout.org_item, inflater, orgs,
                 avatars);
         dropdownAdapter = new OrgListAdapter(layout.org_dropdown_item,
-                inflater, orgItems, avatars);
+                inflater, orgs, avatars);
     }
 
     /**
@@ -155,9 +154,8 @@ public class HomeDropdownListAdapter extends BaseAdapter {
      * @return this adapter
      */
     public HomeDropdownListAdapter setOrgs(final List<User> orgs) {
-        User[] orgItems = orgs.toArray(new User[orgs.size()]);
-        listAdapter.setItems(orgItems);
-        dropdownAdapter.setItems(orgItems);
+        listAdapter.setItems(orgs);
+        dropdownAdapter.setItems(orgs);
         notifyDataSetChanged();
         return this;
     }

--- a/app/src/main/java/com/github/mobile/ui/user/MembersFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/user/MembersFragment.java
@@ -86,8 +86,7 @@ public class MembersFragment extends ItemListFragment<User> implements
     @Override
     protected ItemListAdapter<User, ? extends ItemView> createAdapter(
             List<User> items) {
-        User[] users = items.toArray(new User[items.size()]);
-        return new UserListAdapter(getActivity().getLayoutInflater(), users,
+        return new UserListAdapter(getActivity().getLayoutInflater(), items,
                 avatars);
     }
 

--- a/app/src/main/java/com/github/mobile/ui/user/NewsListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/user/NewsListAdapter.java
@@ -477,7 +477,7 @@ public class NewsListAdapter extends ItemListAdapter<Event, NewsItemView> {
      * @param elements
      * @param avatars
      */
-    public NewsListAdapter(LayoutInflater inflater, Event[] elements,
+    public NewsListAdapter(LayoutInflater inflater, List<Event> elements,
             AvatarLoader avatars) {
         super(layout.news_item, inflater, elements);
 

--- a/app/src/main/java/com/github/mobile/ui/user/PagedUserFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/user/PagedUserFragment.java
@@ -50,8 +50,7 @@ public abstract class PagedUserFragment extends PagedItemFragment<User> {
     @Override
     protected ItemListAdapter<User, ? extends ItemView> createAdapter(
             List<User> items) {
-        User[] users = items.toArray(new User[items.size()]);
-        return new UserListAdapter(getActivity().getLayoutInflater(), users,
+        return new UserListAdapter(getActivity().getLayoutInflater(), items,
                 avatars);
     }
 

--- a/app/src/main/java/com/github/mobile/ui/user/UserListAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/user/UserListAdapter.java
@@ -22,6 +22,8 @@ import com.github.mobile.ui.ItemListAdapter;
 import com.github.mobile.util.AvatarLoader;
 import com.viewpagerindicator.R.layout;
 
+import java.util.List;
+
 import org.eclipse.egit.github.core.User;
 
 /**
@@ -39,7 +41,7 @@ public class UserListAdapter extends ItemListAdapter<User, UserItemView> {
      * @param avatars
      */
     public UserListAdapter(final LayoutInflater inflater,
-            final User[] elements, final AvatarLoader avatars) {
+            final List<User> elements, final AvatarLoader avatars) {
         super(layout.user_item, inflater, elements);
 
         this.avatars = avatars;


### PR DESCRIPTION
This required a bit of reworking of the adapters to use
a list instead of an array and that changed the signature
of the base class constructor which required updates to
all list adapters even those unaffected by the addition
of repository filtering.