### PR TITLE
Inline Intent helper methods

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
@@ -30,16 +30,6 @@ abstract class BaseActivity : DaggerAppCompatActivity(), DialogResultListener {
         setSupportActionBar(findViewById(R.id.toolbar))
     }
 
-    /**
-     * Get intent extra
-     *
-     * @param name
-     * @return char sequence array
-     */
-    protected fun getCharSequenceArrayExtra(name: String): Array<CharSequence>? {
-        return intent.getCharSequenceArrayExtra(name)
-    }
-
     override fun onDialogResult(requestCode: Int, resultCode: Int, arguments: Bundle) {
         // Intentionally left blank
     }

--- a/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
@@ -34,16 +34,6 @@ abstract class BaseActivity : DaggerAppCompatActivity(), DialogResultListener {
      * Get intent extra
      *
      * @param name
-     * @return string
-     */
-    protected fun getStringExtra(name: String): String? {
-        return intent.getStringExtra(name)
-    }
-
-    /**
-     * Get intent extra
-     *
-     * @param name
      * @return string array
      */
     protected fun getStringArrayExtra(name: String): Array<String>? {

--- a/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
@@ -34,16 +34,6 @@ abstract class BaseActivity : DaggerAppCompatActivity(), DialogResultListener {
      * Get intent extra
      *
      * @param name
-     * @return int array
-     */
-    protected fun getIntArrayExtra(name: String): IntArray? {
-        return intent.getIntArrayExtra(name)
-    }
-
-    /**
-     * Get intent extra
-     *
-     * @param name
      * @return boolean array
      */
     protected fun getBooleanArrayExtra(name: String): BooleanArray? {

--- a/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
@@ -34,16 +34,6 @@ abstract class BaseActivity : DaggerAppCompatActivity(), DialogResultListener {
      * Get intent extra
      *
      * @param name
-     * @return string array
-     */
-    protected fun getStringArrayExtra(name: String): Array<String>? {
-        return intent.getStringArrayExtra(name)
-    }
-
-    /**
-     * Get intent extra
-     *
-     * @param name
      * @return char sequence array
      */
     protected fun getCharSequenceArrayExtra(name: String): Array<CharSequence>? {

--- a/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
@@ -34,16 +34,6 @@ abstract class BaseActivity : DaggerAppCompatActivity(), DialogResultListener {
      * Get intent extra
      *
      * @param name
-     * @return boolean array
-     */
-    protected fun getBooleanArrayExtra(name: String): BooleanArray? {
-        return intent.getBooleanArrayExtra(name)
-    }
-
-    /**
-     * Get intent extra
-     *
-     * @param name
      * @return string
      */
     protected fun getStringExtra(name: String): String? {

--- a/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
@@ -16,7 +16,6 @@
 package com.github.pockethub.android.ui.base
 
 import android.os.Bundle
-import android.os.Parcelable
 import com.github.pockethub.android.R
 import com.github.pockethub.android.ui.DialogResultListener
 import dagger.android.support.DaggerAppCompatActivity
@@ -29,16 +28,6 @@ abstract class BaseActivity : DaggerAppCompatActivity(), DialogResultListener {
     override fun onContentChanged() {
         super.onContentChanged()
         setSupportActionBar(findViewById(R.id.toolbar))
-    }
-
-    /**
-     * Get intent extra
-     *
-     * @param name
-     * @return parcelable
-     */
-    protected fun <V : Parcelable> getParcelableExtra(name: String): V? {
-        return intent.getParcelableExtra(name)
     }
 
     /**

--- a/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
@@ -34,16 +34,6 @@ abstract class BaseActivity : DaggerAppCompatActivity(), DialogResultListener {
      * Get intent extra
      *
      * @param name
-     * @return int
-     */
-    protected fun getIntExtra(name: String): Int {
-        return intent.getIntExtra(name, -1)
-    }
-
-    /**
-     * Get intent extra
-     *
-     * @param name
      * @return int array
      */
     protected fun getIntArrayExtra(name: String): IntArray? {

--- a/app/src/main/java/com/github/pockethub/android/ui/base/BaseFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/BaseFragment.kt
@@ -18,12 +18,4 @@ package com.github.pockethub.android.ui.base
 
 import dagger.android.support.DaggerFragment
 
-abstract class BaseFragment : DaggerFragment() {
-
-    /**
-     * Get string extra from activity's intent
-     */
-    protected fun getStringExtra(name: String): String? {
-        return activity?.intent?.getStringExtra(name)
-    }
-}
+abstract class BaseFragment : DaggerFragment()

--- a/app/src/main/java/com/github/pockethub/android/ui/base/BaseFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/BaseFragment.kt
@@ -16,17 +16,9 @@
 
 package com.github.pockethub.android.ui.base
 
-import android.os.Parcelable
 import dagger.android.support.DaggerFragment
 
 abstract class BaseFragment : DaggerFragment() {
-
-    /**
-     * Get parcelable extra from activity's intent
-     */
-    protected fun <V : Parcelable> getParcelableExtra(name: String): V? {
-        return activity?.intent?.getParcelableExtra(name)
-    }
 
     /**
      * Get string extra from activity's intent

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareListFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitCompareListFragment.kt
@@ -88,10 +88,10 @@ class CommitCompareListFragment : BaseFragment(), OnItemClickListener {
     override fun onAttach(context: Context?) {
         super.onAttach(context)
 
-        val activity = context as Activity?
-        repository = activity!!.intent.getParcelableExtra(EXTRA_REPOSITORY)
-        base = getStringExtra(EXTRA_BASE)!!.substring(0, 7)
-        head = getStringExtra(EXTRA_HEAD)!!.substring(0, 7)
+        val activity = context as Activity
+        repository = activity.intent.getParcelableExtra(EXTRA_REPOSITORY)
+        base = activity.intent.getStringExtra(EXTRA_BASE).substring(0, 7)
+        head = activity.intent.getStringExtra(EXTRA_HEAD).substring(0, 7)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitFileViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitFileViewActivity.kt
@@ -89,9 +89,9 @@ class CommitFileViewActivity : BaseActivity() {
         setContentView(R.layout.activity_commit_file_view)
 
         repo = intent.getParcelableExtra(EXTRA_REPOSITORY)
-        commit = getStringExtra(EXTRA_HEAD)
-        sha = getStringExtra(EXTRA_BASE)
-        path = getStringExtra(EXTRA_PATH)
+        commit = intent.getStringExtra(EXTRA_HEAD)
+        sha = intent.getStringExtra(EXTRA_BASE)
+        path = intent.getStringExtra(EXTRA_PATH)
 
         file = CommitUtils.getName(path)
         isMarkdownFile = MarkdownUtils.isMarkdown(file)

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitViewActivity.kt
@@ -53,7 +53,7 @@ class CommitViewActivity : BaseActivity() {
         setContentView(R.layout.activity_pager)
 
         repository = intent.getParcelableExtra(EXTRA_REPOSITORY)
-        ids = getCharSequenceArrayExtra(EXTRA_BASES)
+        ids = intent.getCharSequenceArrayExtra(EXTRA_BASES)
         initialPosition = intent.getIntExtra(EXTRA_POSITION, -1)
 
         val adapter = CommitPagerAdapter(this, repository, ids)

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CommitViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CommitViewActivity.kt
@@ -54,7 +54,7 @@ class CommitViewActivity : BaseActivity() {
 
         repository = intent.getParcelableExtra(EXTRA_REPOSITORY)
         ids = getCharSequenceArrayExtra(EXTRA_BASES)
-        initialPosition = getIntExtra(EXTRA_POSITION)
+        initialPosition = intent.getIntExtra(EXTRA_POSITION, -1)
 
         val adapter = CommitPagerAdapter(this, repository, ids)
         pagerHandler = PagerHandler(this, vp_pages, adapter)

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CreateCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CreateCommentActivity.java
@@ -94,7 +94,7 @@ public class CreateCommentActivity extends
     protected void onCreate(Bundle savedInstanceState) {
         repository = getIntent().getParcelableExtra(EXTRA_REPOSITORY);
         commit = getStringExtra(EXTRA_BASE);
-        position = getIntExtra(EXTRA_POSITION);
+        position = getIntent().getIntExtra(EXTRA_POSITION, -1);
         path = getStringExtra(EXTRA_PATH);
 
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/github/pockethub/android/ui/commit/CreateCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/commit/CreateCommentActivity.java
@@ -93,9 +93,9 @@ public class CreateCommentActivity extends
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         repository = getIntent().getParcelableExtra(EXTRA_REPOSITORY);
-        commit = getStringExtra(EXTRA_BASE);
+        commit = getIntent().getStringExtra(EXTRA_BASE);
         position = getIntent().getIntExtra(EXTRA_POSITION, -1);
-        path = getStringExtra(EXTRA_PATH);
+        path = getIntent().getStringExtra(EXTRA_PATH);
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.pager_with_tabs);

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/CreateCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/CreateCommentActivity.java
@@ -62,7 +62,7 @@ public class CreateCommentActivity extends
         super.onCreate(savedInstanceState);
         setContentView(R.layout.pager_with_tabs);
 
-        gist = getParcelableExtra(EXTRA_GIST);
+        gist = getIntent().getParcelableExtra(EXTRA_GIST);
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(getString(R.string.gist_title) + gist.id());

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/EditCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/EditCommentActivity.java
@@ -69,7 +69,7 @@ public class EditCommentActivity extends
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        gist = getParcelableExtra(EXTRA_GIST);
+        gist = getIntent().getParcelableExtra(EXTRA_GIST);
         comment = getIntent().getParcelableExtra(EXTRA_COMMENT);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.pager_with_tabs);

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFileFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFileFragment.kt
@@ -66,7 +66,7 @@ class GistFileFragment : BaseFragment(), OnSharedPreferenceChangeListener {
     override fun onAttach(context: Context?) {
         super.onAttach(context)
 
-        gistId = getStringExtra(EXTRA_GIST_ID)
+        gistId = activity?.intent?.getStringExtra(EXTRA_GIST_ID)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFilesViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFilesViewActivity.kt
@@ -59,7 +59,7 @@ class GistFilesViewActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_pager_with_title)
 
-        gistId = getStringExtra(EXTRA_GIST_ID)
+        gistId = intent.getStringExtra(EXTRA_GIST_ID)
         initialPosition = intent.getIntExtra(EXTRA_POSITION, -1)
 
         if (initialPosition < 0) {

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistFilesViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistFilesViewActivity.kt
@@ -60,7 +60,7 @@ class GistFilesViewActivity : BaseActivity() {
         setContentView(R.layout.activity_pager_with_title)
 
         gistId = getStringExtra(EXTRA_GIST_ID)
-        initialPosition = getIntExtra(EXTRA_POSITION)
+        initialPosition = intent.getIntExtra(EXTRA_POSITION, -1)
 
         if (initialPosition < 0) {
             initialPosition = 0

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.kt
@@ -70,7 +70,7 @@ class GistsViewActivity : BaseActivity(), OnLoadListener<Gist> {
 
         gists = getStringArrayExtra(EXTRA_GIST_IDS)
         gist = intent.getParcelableExtra(EXTRA_GIST)
-        initialPosition = getIntExtra(EXTRA_POSITION)
+        initialPosition = intent.getIntExtra(EXTRA_POSITION, -1)
 
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
 

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.kt
@@ -69,7 +69,7 @@ class GistsViewActivity : BaseActivity(), OnLoadListener<Gist> {
         setContentView(R.layout.activity_pager)
 
         gists = getStringArrayExtra(EXTRA_GIST_IDS)
-        gist = getParcelableExtra(EXTRA_GIST)
+        gist = intent.getParcelableExtra(EXTRA_GIST)
         initialPosition = getIntExtra(EXTRA_POSITION)
 
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.kt
@@ -68,7 +68,7 @@ class GistsViewActivity : BaseActivity(), OnLoadListener<Gist> {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_pager)
 
-        gists = getStringArrayExtra(EXTRA_GIST_IDS)
+        gists = intent.getStringArrayExtra(EXTRA_GIST_IDS)
         gist = intent.getParcelableExtra(EXTRA_GIST)
         initialPosition = intent.getIntExtra(EXTRA_POSITION, -1)
 

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/CreateCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/CreateCommentActivity.java
@@ -67,7 +67,7 @@ public class CreateCommentActivity extends
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        issueNumber = getIntExtra(EXTRA_ISSUE_NUMBER);
+        issueNumber = getIntent().getIntExtra(EXTRA_ISSUE_NUMBER, -1);
         repositoryId = getIntent().getParcelableExtra(Intents.EXTRA_REPOSITORY);
 
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/CreateCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/CreateCommentActivity.java
@@ -68,7 +68,7 @@ public class CreateCommentActivity extends
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         issueNumber = getIntExtra(EXTRA_ISSUE_NUMBER);
-        repositoryId = getParcelableExtra(Intents.EXTRA_REPOSITORY);
+        repositoryId = getIntent().getParcelableExtra(Intents.EXTRA_REPOSITORY);
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.pager_with_tabs);

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditCommentActivity.java
@@ -80,9 +80,9 @@ public class EditCommentActivity extends
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        comment = getParcelableExtra(EXTRA_COMMENT);
+        comment = getIntent().getParcelableExtra(EXTRA_COMMENT);
         issueNumber = getIntExtra(EXTRA_ISSUE_NUMBER);
-        repositoryId = getParcelableExtra(Intents.EXTRA_REPOSITORY);
+        repositoryId = getIntent().getParcelableExtra(Intents.EXTRA_REPOSITORY);
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.pager_with_tabs);

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditCommentActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditCommentActivity.java
@@ -81,7 +81,7 @@ public class EditCommentActivity extends
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         comment = getIntent().getParcelableExtra(EXTRA_COMMENT);
-        issueNumber = getIntExtra(EXTRA_ISSUE_NUMBER);
+        issueNumber = getIntent().getIntExtra(EXTRA_ISSUE_NUMBER, -1);
         repositoryId = getIntent().getParcelableExtra(Intents.EXTRA_REPOSITORY);
 
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssueBrowseActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssueBrowseActivity.java
@@ -54,7 +54,7 @@ public class IssueBrowseActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_repo_issue_list);
 
-        repo = getParcelableExtra(EXTRA_REPOSITORY);
+        repo = getIntent().getParcelableExtra(EXTRA_REPOSITORY);
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(repo.name());

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesFragment.kt
@@ -85,8 +85,9 @@ class IssuesFragment : BaseFragment() {
     override fun onAttach(context: Context?) {
         super.onAttach(context)
 
-        filter = getParcelableExtra(EXTRA_ISSUE_FILTER)
-        repository = getParcelableExtra(EXTRA_REPOSITORY)
+        val intent = activity?.intent
+        filter = intent?.getParcelableExtra(EXTRA_ISSUE_FILTER)
+        repository = intent?.getParcelableExtra(EXTRA_REPOSITORY)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.kt
@@ -72,7 +72,7 @@ class IssuesViewActivity : BaseActivity() {
         setContentView(R.layout.activity_pager)
 
         issueNumbers = intent.getIntArrayExtra(EXTRA_ISSUE_NUMBERS)
-        pullRequests = getBooleanArrayExtra(EXTRA_PULL_REQUESTS)
+        pullRequests = intent.getBooleanArrayExtra(EXTRA_PULL_REQUESTS)
         repoIds = intent.getParcelableArrayListExtra(EXTRA_REPOSITORIES)
         repo = intent.getParcelableExtra(EXTRA_REPOSITORY)
 

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.kt
@@ -71,7 +71,7 @@ class IssuesViewActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_pager)
 
-        issueNumbers = getIntArrayExtra(EXTRA_ISSUE_NUMBERS)
+        issueNumbers = intent.getIntArrayExtra(EXTRA_ISSUE_NUMBERS)
         pullRequests = getBooleanArrayExtra(EXTRA_PULL_REQUESTS)
         repoIds = intent.getParcelableArrayListExtra(EXTRA_REPOSITORIES)
         repo = intent.getParcelableExtra(EXTRA_REPOSITORY)

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.kt
@@ -112,7 +112,7 @@ class IssuesViewActivity : BaseActivity() {
     }
 
     private fun configurePager() {
-        val initialPosition = getIntExtra(EXTRA_POSITION)
+        val initialPosition = intent.getIntExtra(EXTRA_POSITION, -1)
 
         val adapter = if (repo != null) {
             IssuesPagerAdapter(this, repo, issueNumbers, canWrite)

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.kt
@@ -74,7 +74,7 @@ class IssuesViewActivity : BaseActivity() {
         issueNumbers = getIntArrayExtra(EXTRA_ISSUE_NUMBERS)
         pullRequests = getBooleanArrayExtra(EXTRA_PULL_REQUESTS)
         repoIds = intent.getParcelableArrayListExtra(EXTRA_REPOSITORIES)
-        repo = getParcelableExtra(EXTRA_REPOSITORY)
+        repo = intent.getParcelableExtra(EXTRA_REPOSITORY)
 
         val actionBar = supportActionBar!!
         actionBar.setDisplayHomeAsUpEnabled(true)

--- a/app/src/main/java/com/github/pockethub/android/ui/ref/BranchFileViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/ref/BranchFileViewActivity.kt
@@ -76,9 +76,9 @@ class BranchFileViewActivity : BaseActivity() {
         setContentView(R.layout.activity_commit_file_view)
 
         repo = intent.getParcelableExtra(EXTRA_REPOSITORY)
-        sha = getStringExtra(EXTRA_BASE)
-        path = getStringExtra(EXTRA_PATH)
-        branch = getStringExtra(EXTRA_HEAD)
+        sha = intent.getStringExtra(EXTRA_BASE)
+        path = intent.getStringExtra(EXTRA_PATH)
+        branch = intent.getStringExtra(EXTRA_HEAD)
 
         wv_code.settings.builtInZoomControls = true
         wv_code.settings.useWideViewPort = true

--- a/app/src/main/java/com/github/pockethub/android/ui/ref/BranchFileViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/ref/BranchFileViewActivity.kt
@@ -75,7 +75,7 @@ class BranchFileViewActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_commit_file_view)
 
-        repo = getParcelableExtra(EXTRA_REPOSITORY)
+        repo = intent.getParcelableExtra(EXTRA_REPOSITORY)
         sha = getStringExtra(EXTRA_BASE)
         path = getStringExtra(EXTRA_PATH)
         branch = getStringExtra(EXTRA_HEAD)

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryContributorsActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryContributorsActivity.java
@@ -52,7 +52,7 @@ public class RepositoryContributorsActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_repo_contributors);
 
-        repository = getParcelableExtra(EXTRA_REPOSITORY);
+        repository = getIntent().getParcelableExtra(EXTRA_REPOSITORY);
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(repository.name());

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryContributorsFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryContributorsFragment.kt
@@ -72,7 +72,7 @@ class RepositoryContributorsFragment : BaseFragment() {
     override fun onAttach(context: Context?) {
         super.onAttach(context)
 
-        repo = getParcelableExtra(EXTRA_REPOSITORY)
+        repo = activity?.intent?.getParcelableExtra(EXTRA_REPOSITORY)
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryNewsFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryNewsFragment.java
@@ -48,7 +48,7 @@ public class RepositoryNewsFragment extends NewsFragment {
     public void onAttach(Context context) {
         super.onAttach(context);
 
-        repo = getParcelableExtra(EXTRA_REPOSITORY);
+        repo = requireActivity().getIntent().getParcelableExtra(EXTRA_REPOSITORY);
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryReadmeFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryReadmeFragment.java
@@ -42,7 +42,7 @@ public class RepositoryReadmeFragment extends BaseFragment {
         super.onViewCreated(view, savedInstanceState);
         webview = (WebView) view;
 
-        final Repository repo = getParcelableExtra(Intents.EXTRA_REPOSITORY);
+        final Repository repo = requireActivity().getIntent().getParcelableExtra(Intents.EXTRA_REPOSITORY);
         WebSettings settings = webview.getSettings();
         settings.setJavaScriptEnabled(true);
         webview.addJavascriptInterface(this, "Readme");

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.kt
@@ -70,7 +70,7 @@ class RepositoryViewActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.tabbed_progress_pager)
 
-        repository = getParcelableExtra(EXTRA_REPOSITORY)
+        repository = intent.getParcelableExtra(EXTRA_REPOSITORY)
         val owner = repository!!.owner()!!
 
         val actionBar = supportActionBar!!

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/UserRepositoryListFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/UserRepositoryListFragment.kt
@@ -62,7 +62,7 @@ class UserRepositoryListFragment : BaseFragment() {
     override fun onAttach(context: Context?) {
         super.onAttach(context)
 
-        user = getParcelableExtra(EXTRA_USER)
+        user = activity?.intent?.getParcelableExtra(EXTRA_USER)
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/github/pockethub/android/ui/search/SearchRepositoryListFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/search/SearchRepositoryListFragment.kt
@@ -103,7 +103,7 @@ class SearchRepositoryListFragment : BaseFragment() {
     }
 
     private fun start() {
-        openRepositoryMatch(getStringExtra(QUERY))
+        openRepositoryMatch(activity?.intent?.getStringExtra(QUERY))
     }
 
     fun onItemClick(item: Item<*>, view: View) {
@@ -150,7 +150,7 @@ class SearchRepositoryListFragment : BaseFragment() {
 
 
     private fun loadData(page: Int): Single<Response<Page<Repository>>> {
-        return service.searchRepositories(getStringExtra(QUERY), null, null, page.toLong())
+        return service.searchRepositories(activity?.intent?.getStringExtra(QUERY), null, null, page.toLong())
             .map { response ->
                 val repositorySearchPage = response.body()!!
                 Response.success(Page.builder<Repository>()

--- a/app/src/main/java/com/github/pockethub/android/ui/search/SearchUserListFragment.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/search/SearchUserListFragment.kt
@@ -96,7 +96,7 @@ class SearchUserListFragment : BaseFragment() {
     }
 
     private fun loadData(page: Int): Single<Response<Page<User>>> {
-        return service.searchUsers(getStringExtra(SearchManager.QUERY), null, null, page.toLong())
+        return service.searchUsers(activity?.intent?.getStringExtra(SearchManager.QUERY), null, null, page.toLong())
             .map { response ->
                 val repositorySearchPage = response.body()!!
 

--- a/app/src/main/java/com/github/pockethub/android/ui/user/UserFollowersFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/user/UserFollowersFragment.java
@@ -40,7 +40,7 @@ public class UserFollowersFragment extends FollowersFragment {
     public void onAttach(Context context) {
         super.onAttach(context);
 
-        user = getParcelableExtra(EXTRA_USER);
+        user = requireActivity().getIntent().getParcelableExtra(EXTRA_USER);
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/user/UserFollowingFragment.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/user/UserFollowingFragment.java
@@ -40,7 +40,7 @@ public class UserFollowingFragment extends FollowingFragment {
     public void onAttach(Context context) {
         super.onAttach(context);
 
-        user = getParcelableExtra(EXTRA_USER);
+        user = requireActivity().getIntent().getParcelableExtra(EXTRA_USER);
     }
 
     @Override


### PR DESCRIPTION
Inline `Intent.get___Extra(String)` methods as:

- Logic needs to be duplicated between `BaseFragment` and `BaseActivity` to continue using this approach, reducing code maintainability.
- The helper methods in `BaseFragment` always uses the null permissible `getActivity()` when the logical flow may require the use of the non-null assertive `requireActivity()`.
- Calling `getIntent().get___Extra(String)` is a pretty standard practice, and makes it known that the `get___Extra(String)` is being obtained by the intent that the started the activity.
- `BaseActivity#getIntExtra(name: String)` returns `-1` if the extra `name` is absent. By covering this up in a layer of abstraction is a potential source of difficult to find bugs.