### PR TITLE
Remove style named Global

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,11 +15,6 @@
   -->
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <style name="Global">
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_width">wrap_content</item>
-    </style>
-
     <style name="AvatarXLarge">
         <item name="android:layout_width">40dp</item>
         <item name="android:layout_height">40dp</item>
@@ -40,7 +35,9 @@
         <item name="android:layout_height">16dp</item>
     </style>
 
-    <style name="EditText" parent="Global">
+    <style name="EditText">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
         <item name="android:textColor">@color/text</item>
         <item name="android:textCursorDrawable">@drawable/edit_text_cursor</item>
         <item name="android:textSize">14sp</item>


### PR DESCRIPTION
Explicitly setting the `android:layout_width` and `android:layout_height` to `wrap_content` is much more expressive than subclassing a style called `Global` which tells us nothing of value.