### PR TITLE
Make each interested Activity implement DialogResultListener

### DIFF
--- a/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/BaseActivity.kt
@@ -15,22 +15,13 @@
  */
 package com.github.pockethub.android.ui.base
 
-import android.os.Bundle
 import com.github.pockethub.android.R
-import com.github.pockethub.android.ui.DialogResultListener
 import dagger.android.support.DaggerAppCompatActivity
 
-/**
- * Activity that display dialogs
- */
-abstract class BaseActivity : DaggerAppCompatActivity(), DialogResultListener {
+abstract class BaseActivity : DaggerAppCompatActivity() {
 
     override fun onContentChanged() {
         super.onContentChanged()
         setSupportActionBar(findViewById(R.id.toolbar))
-    }
-
-    override fun onDialogResult(requestCode: Int, resultCode: Int, arguments: Bundle) {
-        // Intentionally left blank
     }
 }

--- a/app/src/main/java/com/github/pockethub/android/ui/base/DialogFragmentHelper.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/base/DialogFragmentHelper.java
@@ -23,6 +23,7 @@ import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.github.pockethub.android.ui.DialogResultListener;
 
 import dagger.android.support.DaggerAppCompatDialogFragment;
 
@@ -93,11 +94,11 @@ public abstract class DialogFragmentHelper extends DaggerAppCompatDialogFragment
      * @param resultCode
      */
     protected void onResult(final int resultCode) {
-        final BaseActivity activity = (BaseActivity) getActivity();
-        if (activity != null) {
+        final DialogResultListener dialogResultListener = (DialogResultListener) getActivity();
+        if (dialogResultListener != null) {
             final Bundle arguments = getArguments();
             if (arguments != null) {
-                activity.onDialogResult(arguments.getInt(ARG_REQUEST_CODE), resultCode, arguments);
+                dialogResultListener.onDialogResult(arguments.getInt(ARG_REQUEST_CODE), resultCode, arguments);
             }
         }
     }

--- a/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/gist/GistsViewActivity.kt
@@ -33,6 +33,7 @@ import com.github.pockethub.android.rx.AutoDisposeUtils
 import com.github.pockethub.android.rx.RxProgress
 import com.github.pockethub.android.ui.base.BaseActivity
 import com.github.pockethub.android.ui.ConfirmDialogFragment
+import com.github.pockethub.android.ui.DialogResultListener
 import com.github.pockethub.android.ui.MainActivity
 import com.github.pockethub.android.ui.helpers.PagerHandler
 import com.github.pockethub.android.ui.item.gist.GistItem
@@ -51,7 +52,7 @@ import javax.inject.Inject
 /**
  * Activity to display a collection of Gists in a pager
  */
-class GistsViewActivity : BaseActivity(), OnLoadListener<Gist> {
+class GistsViewActivity : BaseActivity(), DialogResultListener, OnLoadListener<Gist> {
 
     @Inject
     lateinit var store: GistStore
@@ -142,8 +143,6 @@ class GistsViewActivity : BaseActivity(), OnLoadListener<Gist> {
 
         pagerHandler!!.adapter
             .onDialogResult(vp_pages.currentItem, requestCode, resultCode, arguments)
-
-        super.onDialogResult(requestCode, resultCode, arguments)
     }
 
     private fun onPageChanged(position: Int) {

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditIssueActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditIssueActivity.kt
@@ -45,6 +45,7 @@ import com.github.pockethub.android.accounts.AccountUtils
 import com.github.pockethub.android.core.issue.IssueUtils
 import com.github.pockethub.android.rx.AutoDisposeUtils
 import com.github.pockethub.android.rx.RxProgress
+import com.github.pockethub.android.ui.DialogResultListener
 import com.github.pockethub.android.ui.base.BaseActivity
 import com.github.pockethub.android.ui.TextWatcherAdapter
 import com.github.pockethub.android.util.AvatarLoader
@@ -71,7 +72,7 @@ import javax.inject.Inject
 /**
  * Activity to edit or create an issue
  */
-class EditIssueActivity : BaseActivity() {
+class EditIssueActivity : BaseActivity(), DialogResultListener {
 
     @Inject
     lateinit var avatars: AvatarLoader

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/EditIssuesFilterActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/EditIssuesFilterActivity.kt
@@ -25,6 +25,7 @@ import com.github.pockethub.android.Intents.Builder
 import com.github.pockethub.android.Intents.EXTRA_ISSUE_FILTER
 import com.github.pockethub.android.R
 import com.github.pockethub.android.core.issue.IssueFilter
+import com.github.pockethub.android.ui.DialogResultListener
 import com.github.pockethub.android.ui.base.BaseActivity
 import com.github.pockethub.android.util.AvatarLoader
 import com.github.pockethub.android.util.InfoUtils
@@ -34,7 +35,7 @@ import javax.inject.Inject
 /**
  * Activity to create or edit an issues filter for a repository
  */
-class EditIssuesFilterActivity : BaseActivity() {
+class EditIssuesFilterActivity : BaseActivity(), DialogResultListener {
 
     @Inject
     lateinit var avatars: AvatarLoader

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/FiltersViewActivity.java
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/FiltersViewActivity.java
@@ -23,6 +23,7 @@ import com.github.pockethub.android.Intents.Builder;
 import com.github.pockethub.android.R;
 import com.github.pockethub.android.core.issue.IssueFilter;
 import com.github.pockethub.android.persistence.AccountDataManager;
+import com.github.pockethub.android.ui.DialogResultListener;
 import com.github.pockethub.android.ui.base.BaseActivity;
 import com.github.pockethub.android.ui.MainActivity;
 import io.reactivex.disposables.CompositeDisposable;
@@ -37,7 +38,7 @@ import static com.github.pockethub.android.ui.issue.FilterListFragment.REQUEST_D
 /**
  * Activity to display a list of saved {@link IssueFilter} objects
  */
-public class FiltersViewActivity extends BaseActivity {
+public class FiltersViewActivity extends BaseActivity implements DialogResultListener {
 
     private CompositeDisposable disposables;
 
@@ -80,10 +81,7 @@ public class FiltersViewActivity extends BaseActivity {
                                 }
                             })
             );
-            return;
         }
-
-        super.onDialogResult(requestCode, resultCode, arguments);
     }
 
     @Override

--- a/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/issue/IssuesViewActivity.kt
@@ -29,6 +29,7 @@ import com.github.pockethub.android.R
 import com.github.pockethub.android.core.issue.IssueStore
 import com.github.pockethub.android.core.issue.IssueUtils
 import com.github.pockethub.android.rx.AutoDisposeUtils
+import com.github.pockethub.android.ui.DialogResultListener
 import com.github.pockethub.android.ui.base.BaseActivity
 import com.github.pockethub.android.ui.helpers.PagerHandler
 import com.github.pockethub.android.ui.repo.RepositoryViewActivity
@@ -48,7 +49,7 @@ import javax.inject.Inject
 /**
  * Activity to display a collection of issues or pull requests in a pager
  */
-class IssuesViewActivity : BaseActivity() {
+class IssuesViewActivity : BaseActivity(), DialogResultListener {
 
     @Inject
     lateinit var store: IssueStore

--- a/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.kt
+++ b/app/src/main/java/com/github/pockethub/android/ui/repo/RepositoryViewActivity.kt
@@ -31,6 +31,7 @@ import com.github.pockethub.android.R
 import com.github.pockethub.android.ResultCodes.RESOURCE_CHANGED
 import com.github.pockethub.android.core.repo.RepositoryUtils
 import com.github.pockethub.android.rx.AutoDisposeUtils
+import com.github.pockethub.android.ui.DialogResultListener
 import com.github.pockethub.android.ui.base.BaseActivity
 import com.github.pockethub.android.ui.helpers.PagerHandler
 import com.github.pockethub.android.ui.user.UriLauncherActivity
@@ -54,7 +55,7 @@ import retrofit2.Response
 /**
  * Activity to view a repository
  */
-class RepositoryViewActivity : BaseActivity() {
+class RepositoryViewActivity : BaseActivity(), DialogResultListener {
 
     private var repository: Repository? = null
 


### PR DESCRIPTION
Unanimously making each activity an implementation of `DialogResultListener` can cause hidden bugs, i.e., returning a result to activity which shouldn't handle it. Also, this aligns with the fact that only the interested fragments implement `DialogResultListener`.